### PR TITLE
feat: show finder for non-session soruce by default

### DIFF
--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -35,7 +35,8 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
 + (id<FBResponsePayload>)handleGetSourceCommand:(FBRouteRequest *)request
 {
   // This method might be called without session
-  XCUIApplication *application = request.session.currentApplication ?: [XCUIApplication new];
+  XCUIApplication *application = request.session.currentApplication
+    ?: [[XCUIApplication alloc] initWithBundleIdentifier:FINDER_BUNDLE_ID];
   NSString *sourceType = request.parameters[@"format"] ?: SOURCE_FORMAT_XML;
   id result;
   if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_XML] == NSOrderedSame) {


### PR DESCRIPTION
When I read https://github.com/appium/appium-mac2-driver/pull/11, I noticed in no-session route of `/source`.
No session source route returned the below message.


```
{
  "value" : {
    "error" : "unknown error",
    "message" : "No target application path specified via test configuration: <XCTestConfiguration: 0x600003d00780>\n\t                  testBundleURL:file:\/\/\/Users\/kazuaki\/Library\/Developer\/Xcode\/DerivedData\/WebDriverAgentMac-arpthcvohjdzehhbujinjzomymkj\/Build\/Products\/Debug\/WebDriverAgentRunner-Runner.app\/Contents\/PlugIns\/WebDriverAgentRunner.xctest\/\n\t         testBundleRelativePath:__TESTHOST__\/Contents\/PlugIns\/WebDriverAgentRunner.xctest\n\t              productModuleName:WebDriverAgentRunner\n\t                    testsToSkip:(null)\n\t                     testsToRun:(null)\n\t             reportResultsToIDE:YES\n\t               testsDrivenByIDE:no\n\t              sessionIdentifier:0F708101-4CBF-4E1D-AE17-82DFBD47A68A\n\t      disablePerformanceMetrics:no\n\ttreatMissingBaselinesAsFailures:no\n\t                baselineFileURL:(null)\n\t       baselineFileRelativePath:(null)\n\t          targetApplicationPath:(null)\n\t      targetApplicationBundleID:(null)\n\t testApplicationDependencies:\n{\n    \"io.appium.WebDriverAgentRunner.xctrunner\" = \"\/Users\/kazuaki\/Library\/Developer\/Xcode\/DerivedData\/WebDriverAgentMac-arpthcvohjdzehhbujinjzomymkj\/Build\/Products\/Debug\/WebDriverAgentRunner-Runner.app\";\n}\n\t testApplicationUserOverrides:(null)\n\t     targetApplicationArguments:\n\t   targetApplicationEnvironment:\n{\n    \"DYLD_FRAMEWORK_PATH\" = \"\/Users\/kazuaki\/Library\/Developer\/
  ...
```

It would be better to show Finder as our default value in this case like iOS's home, I think.
How about this change?