### PR TITLE
chore: modify scheme

### DIFF
--- a/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "NO"
+            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">
@@ -74,6 +74,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71688B1325646A620007F55B"
+            BuildableName = "WebDriverAgentRunner.xctest"
+            BlueprintName = "WebDriverAgentRunner"
+            ReferencedContainer = "container:WebDriverAgentMac.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
`xcodebuild clean -project /Users/kazu/GitHub/appium/node_modules/appium-mac2-driver/WebDriverAgentMac/WebDriverAgentMac.xcodeproj -scheme WebDriverAgentRunner` raised 70 status code as below.

```
% xcodebuild clean -project /Users/kazu/GitHub/appium/node_modules/appium-mac2-driver/WebDriverAgentMac/WebDriverAgentMac.xcodeproj -scheme WebDriverAgentRunner
Command line invocation:
    /Applications/Xcode_12.2.app/Contents/Developer/usr/bin/xcodebuild clean -project /Users/kazuaki/GitHub/appium/node_modules/appium-mac2-driver/WebDriverAgentMac/WebDriverAgentMac.xcodeproj -scheme WebDriverAgentRunner

xcodebuild: error: Failed to build project WebDriverAgentMac with scheme WebDriverAgentRunner.
	Reason: The scheme 'WebDriverAgentRunner' is not configured for Running.
	Recovery suggestion: The scheme 'WebDriverAgentRunner' has nothing configured to build for Running and has no executable specified to Run. Edit the scheme to configure the Run action.
```

This PR enabled below `Run` checkbox.
![image](https://user-images.githubusercontent.com/5511591/101276549-18580600-37f1-11eb-9f70-13ba8fcfc5f8.png)

On my local, after this change the clean command worked...