### PR TITLE
fix: Fix clicking by absolute coordinates

### DIFF
--- a/WebDriverAgentMac/IntegrationTests/AMElementAttributesTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMElementAttributesTests.m
@@ -21,6 +21,7 @@
 #import "XCUIElement+AMAttributes.h"
 #import "XCUIElement+AMEditable.h"
 #import "XCUIElement+AMHitPoint.h"
+#import "XCUIElement+AMCoordinates.h"
 
 
 @interface AMElementAttributesTests : AMIntegrationTestCase
@@ -82,6 +83,14 @@
   XCUIElement *button = [self.testedApplication.buttons matchingPredicate:predicate].firstMatch;
   NSString *enabled = [button am_wdAttributeValueWithName:@"enabled"];
   XCTAssertEqualObjects(enabled, @"false");
+}
+
+- (void)testAppCoordinates
+{
+  CGPoint buttonCoords = CGPointMake(20, 30);
+  XCUICoordinate *abosuluteCoordinate = [self.testedApplication am_coordinateWithPoint:buttonCoords];
+  XCTAssertEqualWithAccuracy(abosuluteCoordinate.screenPoint.x, buttonCoords.x, 0.1);
+  XCTAssertEqualWithAccuracy(abosuluteCoordinate.screenPoint.y, buttonCoords.y, 0.1);
 }
 
 - (void)testSliderValueAttribute

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMCoordinates.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMCoordinates.m
@@ -16,11 +16,80 @@
 
 #import "XCUIElement+AMCoordinates.h"
 
+#import "FBExceptions.h"
+#import "XCUIApplication+AMHelpers.h"
+
+@interface XCUIElementDouble : NSObject
+@property (nonatomic) CGRect frame;
+@end
+
+@implementation XCUIElementDouble
+@end
+
+@interface XCUIElementProxy : NSProxy
+@property (nonatomic) NSArray<NSObject *> *targets;
+
+- (instancetype)initWithTargets:(NSArray<NSObject *> *)targets;
+@end
+
+@implementation XCUIElementProxy
+
+- (instancetype)initWithTargets:(NSArray<NSObject *> *)targets {
+  _targets = targets;
+  return self;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  for (NSObject *target in self.targets) {
+    if ([target methodSignatureForSelector:invocation.selector]) {
+      [invocation setTarget:target];
+      [invocation invoke];
+      return;
+    }
+  }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+  for (NSObject *target in self.targets) {
+    NSMethodSignature *signature = [target methodSignatureForSelector:sel];
+    if (signature) {
+      return signature;
+    }
+  }
+  return [super methodSignatureForSelector:sel];
+}
+
+@end
+
+
 @implementation XCUIElement (AMCoordinates)
 
 - (XCUICoordinate *)am_coordinateWithX:(CGFloat)x andY:(CGFloat)y
 {
-  return [self coordinateWithNormalizedOffset:CGVectorMake(x, y)];
+  CGRect frame = [self isKindOfClass:XCUIApplication.class]
+    ? [(XCUIApplication *)self am_screenRect]
+    : self.frame;
+  XCUICoordinate *result = [self coordinateWithNormalizedOffset:CGVectorMake(x / frame.size.width,
+                                                                             y / frame.size.height)];
+  if ([self isKindOfClass:XCUIApplication.class]) {
+    // This is a hack needed to make aboslute coordinates work
+    // with application element. By default XCTest returns zero-sized
+    // rectangle for XCUIApplication elements
+    XCUIElementDouble *fakeEl = [XCUIElementDouble new];
+    fakeEl.frame = [(XCUIApplication *)self am_screenRect];
+    XCUIElementProxy *elementProxy = [[XCUIElementProxy alloc] initWithTargets:@[fakeEl, self]];
+    [result setValue:elementProxy forKey:@"_element"];
+  }
+  CGPoint screenPoint = result.screenPoint;
+  if (screenPoint.x == INFINITY || screenPoint.y == INFINITY) {
+    NSString *reason = [NSString stringWithFormat:@"Screen coordinates cannot be calculated for '%@'. Consider selecting another element", self.description];
+    @throw [NSException exceptionWithName:FBInvalidElementStateException
+                                   reason:reason
+                                 userInfo:@{}];
+  }
+  return result;
 }
 
 - (XCUICoordinate *)am_coordinateWithPoint:(CGPoint)point

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMCoordinates.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMCoordinates.m
@@ -74,9 +74,9 @@
   XCUICoordinate *result = [self coordinateWithNormalizedOffset:CGVectorMake(x / frame.size.width,
                                                                              y / frame.size.height)];
   if ([self isKindOfClass:XCUIApplication.class]) {
-    // This is a hack needed to make aboslute coordinates work
-    // with application element. By default XCTest returns zero-sized
-    // rectangle for XCUIApplication elements
+    // This is a hack needed to make absolute coordinates work
+    // with the application element. By default XCTest returns zero-sized
+    // rectangle for XCUIApplication nodes
     XCUIElementDouble *fakeEl = [XCUIElementDouble new];
     fakeEl.frame = [(XCUIApplication *)self am_screenRect];
     XCUIElementProxy *elementProxy = [[XCUIElementProxy alloc] initWithTargets:@[fakeEl, self]];

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMGeometryUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMGeometryUtils.m
@@ -17,10 +17,11 @@
 #import "AMGeometryUtils.h"
 
 NSDictionary<NSString *, NSNumber *> *AMCGRectToDict(CGRect frame) {
+  CGRect integralFrame = CGRectIntegral(frame);
   return @{
-    @"x": @(CGRectGetMinX(frame)),
-    @"y": @(CGRectGetMinY(frame)),
-    @"width": @(CGRectGetWidth(frame)),
-    @"height": @(CGRectGetHeight(frame)),
+    @"x": @(CGRectGetMinX(integralFrame)),
+    @"y": @(CGRectGetMinY(integralFrame)),
+    @"width": @(CGRectGetWidth(integralFrame)),
+    @"height": @(CGRectGetHeight(integralFrame)),
   };
 }

--- a/test/functional/interaction-e2e-specs.js
+++ b/test/functional/interaction-e2e-specs.js
@@ -1,4 +1,4 @@
-// import _ from 'lodash';
+import _ from 'lodash';
 import wd from 'wd';
 import { startServer } from '../..';
 import chaiAsPromised from 'chai-as-promised';
@@ -11,6 +11,7 @@ chai.use(chaiAsPromised);
 const CAPS = {
   platformName: 'mac',
   bundleId: TEXT_EDIT_BUNDLE_ID,
+  showServerLogs: true,
 };
 
 describe('Mac2Driver - elements interaction', function () {
@@ -45,6 +46,17 @@ describe('Mac2Driver - elements interaction', function () {
     const el = await driver.elementByClassName('XCUIElementTypeTextView');
     await el.sendKeys('hello world');
     await el.text().should.eventually.eql('hello world');
+  });
+
+  it('should click a button by absolute coordinate', async function () {
+    const el = _.first(await driver.elements('-ios predicate string', 'elementType == 12 AND label == "bold"'));
+    const {x, y, width, height} = await el.getAttribute('frame');
+    await driver.execute('macos: click', {
+      x: x + width / 2,
+      y: y + height / 2,
+    });
+    const els = await driver.elements('-ios predicate string', 'value == "Bold" AND label == "type face"');
+    els.length.should.eql(1);
   });
 
   it('should clear a text view', async function () {


### PR DESCRIPTION
XCTest on MacOS returns application frame as (0,0,0,0), which prevents clicks and other operations on it. This hack adds a possibility to perform clicks properly