### PR TITLE
fix: Only start the app after the previous session has been cleaned up

### DIFF
--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -82,10 +82,13 @@ const static NSString *CAPABILITIES_KEY = @"capabilities";
   }
 
   NSString *bundleID = requirements[AM_BUNDLE_ID_CAPABILITY];
-  XCUIApplication *app = nil;
   BOOL noReset = [requirements[AM_NO_RESET_CAPABILITY] boolValue];
-  if (bundleID != nil) {
-    app = [[XCUIApplication alloc] initWithBundleIdentifier:bundleID];
+  FBSession *session;
+  if (nil == bundleID) {
+    session = [FBSession initWithApplication:nil];
+  } else {
+    XCUIApplication *app = [[XCUIApplication alloc] initWithBundleIdentifier:bundleID];
+    session = [FBSession initWithApplication:app];
     if (noReset && app.state > XCUIApplicationStateNotRunning) {
       [app activate];
     } else {
@@ -99,7 +102,6 @@ const static NSString *CAPABILITIES_KEY = @"capabilities";
       }
     }
   }
-  FBSession *session = [FBSession initWithApplication:app];
   if (nil != requirements[AM_SKIP_APP_KILL_CAPABILITY]) {
     session.skipAppTermination = [requirements[AM_SKIP_APP_KILL_CAPABILITY] boolValue];
   } else if (nil == bundleID) {

--- a/WebDriverAgentMac/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Routing/FBSession.m
@@ -77,7 +77,7 @@ static FBSession *_activeSession = nil;
 {
   if (nil != self.testedApplication) {
     if (self.testedApplication.state <= XCUIApplicationStateNotRunning) {
-      NSString *description = @"The application under test with is not running, possibly crashed";
+      NSString *description = @"The application under test is not running, possibly crashed";
       @throw [NSException exceptionWithName:FBApplicationCrashedException reason:description userInfo:nil];
     }
     return self.testedApplication;


### PR DESCRIPTION
Addresses https://github.com/appium/appium-mac2-driver/issues/37