### PR TITLE
feat: capture the window of AUT in session

### DIFF
--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
@@ -32,9 +32,9 @@
 {
   XCUIScreenshot *screenshot;
   if (FBSession.activeSession) {
-      screenshot = FBSession.activeSession.currentApplication.windows.firstMatch.screenshot;
+    screenshot = FBSession.activeSession.currentApplication.windows.firstMatch.screenshot;
   } else {
-      screenshot = XCUIScreen.mainScreen.screenshot;
+    screenshot = XCUIScreen.mainScreen.screenshot;
   }
 
   NSData *screenshotData = [screenshot PNGRepresentation];

--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
@@ -30,20 +30,22 @@
 
 + (id<FBResponsePayload>)handleGetScreenshot:(FBRouteRequest *)request
 {
-  NSData *screenshotData;
+  XCUIScreenshot *screenshot;
   if (FBSession.activeSession) {
-    screenshotData = [FBSession.activeSession.currentApplication.windows.firstMatch.screenshot PNGRepresentation];
+      screenshot = FBSession.activeSession.currentApplication.windows.firstMatch.screenshot;
   } else {
-    screenshotData = [[[XCUIScreen mainScreen] screenshot] PNGRepresentation];
+      screenshot = XCUIScreen.mainScreen.screenshot;
   }
+
+  NSData *screenshotData = [screenshot PNGRepresentation];
 
   if (nil == screenshotData) {
     NSString *message = @"Cannot take a screenshot of the main screen";
     return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:message
                                                                              traceback:nil]);
   }
-  NSString *screenshot = [screenshotData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-  return FBResponseWithObject(screenshot);
+  NSString *b64screenshot = [screenshotData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+  return FBResponseWithObject(b64screenshot);
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
@@ -10,6 +10,7 @@
 #import "FBScreenshotCommands.h"
 
 #import "XCTest/XCTest.h"
+#import "FBSession.h"
 
 @implementation FBScreenshotCommands
 
@@ -29,7 +30,13 @@
 
 + (id<FBResponsePayload>)handleGetScreenshot:(FBRouteRequest *)request
 {
-  NSData *screenshotData = [[[XCUIScreen mainScreen] screenshot] PNGRepresentation];
+  NSData *screenshotData;
+  if (FBSession.activeSession) {
+    screenshotData = [FBSession.activeSession.currentApplication.windows.firstMatch.screenshot PNGRepresentation];
+  } else {
+    screenshotData = [[[XCUIScreen mainScreen] screenshot] PNGRepresentation];
+  }
+
   if (nil == screenshotData) {
     NSString *message = @"Cannot take a screenshot of the main screen";
     return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:message


### PR DESCRIPTION
For now, `/screenshot` returns the entire desktop screen, but what about returning the AUT window in session?

So,

no session -> then, the API returns desktop
in session -> then, the API returns the AUT window area
https://developer.apple.com/documentation/xctest/xcuiscreenshot

This is because `XCUIElementTypeApplication` in the top element in a page source for the AUT is the AUT window. It does not include outside the AUT. So, I think it is natural to have only the AUT window in the screenshot.