### PR TITLE
feat: add webDriverAgentMacUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Capability Name | Description
 platformName | Should be set to `mac`
 automationName | Must always be set to `mac2`. Values of automationName are compared case-insensitively.
 appium:systemPort | The number of the port for the driver to listen on. If not provided then Appium will use the default port `10100`.
+appium:WebDriverAgentMacUrl | Appium will connect to an existing WebDriverAgentMac instance at this URL instead of starting a new one.
 appium:showServerLogs | Set it to `true` in order to include xcodebuild output to the Appium server log. `false` by default.
 appium:bootstrapRoot | The full path to `WebDriverAgentMac` root folder where Xcode project of the server sources lives. By default this project is located in the same folder where the corresponding driver Node.js module lives.
 appium:serverStartupTimeout | The number of milliseconds to wait util the WebDriverAgentMac project is built and started. `120000` by default

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Capability Name | Description
 platformName | Should be set to `mac`
 automationName | Must always be set to `mac2`. Values of automationName are compared case-insensitively.
 appium:systemPort | The number of the port for the driver to listen on. If not provided then Appium will use the default port `10100`.
-appium:webDriverAgentMacUrl | Appium will connect to an existing WebDriverAgentMac instance at this URL instead of starting a new one.
+appium:webDriverAgentMacUrl | Appium will connect to an existing WebDriverAgentMac instance at this URL instead of starting a new one. e.g. `http://192.168.10.1:10101`
 appium:showServerLogs | Set it to `true` in order to include xcodebuild output to the Appium server log. `false` by default.
 appium:bootstrapRoot | The full path to `WebDriverAgentMac` root folder where Xcode project of the server sources lives. By default this project is located in the same folder where the corresponding driver Node.js module lives.
 appium:serverStartupTimeout | The number of milliseconds to wait util the WebDriverAgentMac project is built and started. `120000` by default

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Capability Name | Description
 platformName | Should be set to `mac`
 automationName | Must always be set to `mac2`. Values of automationName are compared case-insensitively.
 appium:systemPort | The number of the port for the driver to listen on. If not provided then Appium will use the default port `10100`.
-appium:WebDriverAgentMacUrl | Appium will connect to an existing WebDriverAgentMac instance at this URL instead of starting a new one.
+appium:webDriverAgentMacUrl | Appium will connect to an existing WebDriverAgentMac instance at this URL instead of starting a new one.
 appium:showServerLogs | Set it to `true` in order to include xcodebuild output to the Appium server log. `false` by default.
 appium:bootstrapRoot | The full path to `WebDriverAgentMac` root folder where Xcode project of the server sources lives. By default this project is located in the same folder where the corresponding driver Node.js module lives.
 appium:serverStartupTimeout | The number of milliseconds to wait util the WebDriverAgentMac project is built and started. `120000` by default

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -32,7 +32,7 @@ const desiredCapConstraints = {
   postrun: {
     isObject: true
   },
-  webDriverAgentUrl: {
+  WebDriverAgentMacUrl: {
     isString: true
   }
 };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -31,6 +31,9 @@ const desiredCapConstraints = {
   },
   postrun: {
     isObject: true
+  },
+  webDriverAgentUrl: {
+    isString: true
   }
 };
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -32,7 +32,7 @@ const desiredCapConstraints = {
   postrun: {
     isObject: true
   },
-  WebDriverAgentMacUrl: {
+  webDriverAgentMacUrl: {
     isString: true
   }
 };

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -267,6 +267,15 @@ class WDAMacServer {
     return !!(this.process?.isRunning);
   }
 
+  /**
+   * Returns true if the WDAMac server is proxying requests
+   *
+   * @return {boolean}
+   */
+  get isProxying () {
+    return !!this.proxy;
+  }
+
   async isProxyReady (throwOnExit = true) {
     if (!this.proxy) {
       return false;
@@ -319,7 +328,7 @@ class WDAMacServer {
 
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
-    const wasProcessInitNecessary = !caps.webDriverAgentMacUrl ? await this.process.init(caps) : false;
+    const wasProcessInitNecessary = !caps.webDriverAgentMacUrl ? await this.process.init(caps) : true;
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
       const {scheme, server, port, path} = this.parseProxyProperties(caps.webDriverAgentMacUrl);
@@ -354,12 +363,16 @@ class WDAMacServer {
         }
         throw e;
       }
-      const pid = this.process.pid;
 
-      const childrenPids = await this.process.listChildrenPids();
-      RUNNING_PROCESS_IDS.push(...childrenPids, pid);
-      this.process.proc?.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
-      log.info(`The host process is ready within ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+      if (caps.webDriverAgentMacUrl) {
+        log.info(`Proxying requests to ${scheme}://${server}:${port}${path}`);
+      } else {
+        const pid = this.process.pid;
+        const childrenPids = await this.process.listChildrenPids();
+        RUNNING_PROCESS_IDS.push(...childrenPids, pid);
+        this.process.proc.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
+        log.info(`The host process is ready within ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+      }
     } else {
       log.info('The host process has already been listening. Proceeding with session creation');
     }
@@ -373,7 +386,7 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    if (!this.isRunning) {
+    if (!this.isRunning && !this.isProxying) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }
@@ -386,10 +399,7 @@ class WDAMacServer {
       }
     }
 
-    if (this.proxy) {
-      // TODO: Modify? should check this condition
-      this.proxy.didProcessExit = false;
-    }
+    this.proxy = null;
   }
 }
 

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -272,6 +272,8 @@ class WDAMacServer {
 
   /**
    * Returns true if the proxy instance is ready
+   *
+   * @return {boolean}
    */
   shouldPrepareProxy () {
     if (this.isProxyingToRemoteServer) {

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -286,7 +286,7 @@ class WDAMacServer {
 
 
   /**
-   * @typedef {Object} ProxyToInfo
+   * @typedef {Object} ProxyProperties
    *
    * @property {string} scheme - The scheme proxy to.
    * @property {string} host - The host name proxy to.
@@ -297,25 +297,25 @@ class WDAMacServer {
   /**
    * Returns information about proxy information which WDAMacServer proxy to.
    *
-   * @param {Object} caps - The capabilities provided by a client
-   * @return {ProxyToInfo}
+   * @param {?string} wdaUrl - The URL for WDAMacServer app to proxy requests to.
+   * @return {ProxyProperties}
    */
-  getProxyToInfo (caps) {
+  parseProxyProperties (wdaUrl) {
     let scheme = 'http';
-    if (_.isString(caps.webDriverAgentMacUrl)) {
-      const {protocol, hostname, port, pathname} = url.parse(caps.webDriverAgentMacUrl);
-      if (_.isString(protocol)) {
-        scheme = protocol.split(':')[0];
-      }
-      return {
-        scheme,
-        host: hostname ?? HOST,
-        port: _.isNull(port) ? DEFAULT_SYSTEM_PORT : _.parseInt(port),
-        path: pathname === '/' ? '' : pathname
-      };
+    if (!_.isString(wdaUrl)) {
+      return {scheme, host: HOST, port: this.process.port, path: ''};
     }
 
-    return {scheme, host: HOST, port: this.process.port, path: ''};
+    const {protocol, hostname, port, pathname} = url.parse(wdaUrl);
+    if (_.isString(protocol)) {
+      scheme = protocol.split(':')[0];
+    }
+    return {
+      scheme,
+      host: hostname ?? HOST,
+      port: _.isNil(port) ? DEFAULT_SYSTEM_PORT : _.parseInt(port),
+      path: pathname === '/' ? '' : pathname
+    };
   }
 
   async startSession (caps) {
@@ -323,7 +323,7 @@ class WDAMacServer {
     const wasProcessInitNecessary = await this.process.init(caps);
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
-      const {scheme, server, port, path} = this.getProxyToInfo(caps);
+      const {scheme, server, port, path} = this.parseProxyProperties(caps.webDriverAgentMacUrl);
       this.proxy = new WDAMacProxy({
         scheme,
         server,

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -360,7 +360,7 @@ class WDAMacServer {
     let wasProcessInitNecessary;
     if (this.isProxyingToRemoteServer) {
       if (this.process) {
-        await this.process.stop();
+        await this.process.kill();
         await cleanupObsoleteProcesses();
         this.process = null;
       }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -271,7 +271,7 @@ class WDAMacServer {
   }
 
   /**
-   * Returns true if the proxy instance is ready
+   * Returns true if WDAMacServer should prepare proxy instance
    *
    * @return {boolean}
    */

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -347,7 +347,7 @@ class WDAMacServer {
     if (this.isProxyingToRemoteServer) {
       wasProcessInitNecessary = false;
     } else {
-      this.process = new WDAMacProcess();
+      if (!this.process) { this.process = new WDAMacProcess(); }
       wasProcessInitNecessary = await this.process.init(caps);
     }
 

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -144,11 +144,6 @@ class WDAMacProcess {
       return false;
     }
 
-    if (opts.webDriverAgentMacUrl) {
-      // Skip to init WDA server
-      return true;
-    }
-
     this.showServerLogs = opts.showServerLogs ?? this.showServerLogs;
     this.port = opts.systemPort ?? this.port;
     this.host = opts.systemHost ?? this.host;
@@ -324,7 +319,7 @@ class WDAMacServer {
 
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
-    const wasProcessInitNecessary = await this.process.init(caps);
+    const wasProcessInitNecessary = !caps.webDriverAgentMacUrl ? await this.process.init(caps) : false;
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
       const {scheme, server, port, path} = this.parseProxyProperties(caps.webDriverAgentMacUrl);
@@ -336,6 +331,7 @@ class WDAMacServer {
         keepAlive: true,
       });
       this.proxy.didProcessExit = false;
+
       this.process.proc?.on('exit', () => {
         this.proxy.didProcessExit = true;
       });
@@ -359,6 +355,7 @@ class WDAMacServer {
         throw e;
       }
       const pid = this.process.pid;
+
       const childrenPids = await this.process.listChildrenPids();
       RUNNING_PROCESS_IDS.push(...childrenPids, pid);
       this.process.proc?.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
@@ -387,6 +384,11 @@ class WDAMacServer {
       } catch (e) {
         log.info(`Mac2Driver session cannot be deleted. Original error: ${e.message}`);
       }
+    }
+
+    if (this.proxy) {
+      // TODO: Modify? should check this condition
+      this.proxy.didProcessExit = false;
     }
   }
 }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -143,7 +143,7 @@ class WDAMacProcess {
       return false;
     }
 
-    if (_.isString(opts.webDriverAgentMacUrl)) {
+    if (opts.webDriverAgentMacUrl) {
       // Skip to init WDA server
       return true;
     }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -297,6 +297,7 @@ class WDAMacServer {
    *
    * @param {Object} caps - The capabilities in the session.
    * @return {ProxyProperties}
+   * @throws Error if 'webDriverAgentMacUrl' had invalid URL
    */
   parseProxyProperties (caps) {
     let scheme = 'http';
@@ -309,14 +310,22 @@ class WDAMacServer {
       };
     }
 
-    const {protocol, hostname, port, pathname} = url.parse(caps.webDriverAgentMacUrl);
+    let parsed_url;
+    try {
+      parsed_url = new url.URL(caps.webDriverAgentMacUrl);
+    } catch (e) {
+      throw new Error(`webDriverAgentMacUrl, '${caps.webDriverAgentMacUrl}', ` +
+        `in the capabilities is invalid. ${e.message}`);
+    }
+
+    const { protocol, hostname, port, pathname } = parsed_url;
     if (_.isString(protocol)) {
       scheme = protocol.split(':')[0];
     }
     return {
       scheme,
       server: hostname ?? DEFAULT_SYSTEM_HOST,
-      port: _.isNil(port) ? DEFAULT_SYSTEM_PORT : _.parseInt(port),
+      port: _.isEmpty(port) ? DEFAULT_SYSTEM_PORT : _.parseInt(port),
       path: pathname === '/' ? '' : pathname
     };
   }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -276,11 +276,7 @@ class WDAMacServer {
    * @return {boolean}
    */
   shouldPrepareProxy () {
-    if (this.isProxyingToRemoteServer) {
-      return true;
-    }
-
-    if (!this.proxy) {
+    if (this.isProxyingToRemoteServer || !this.proxy) {
       return true;
     }
 
@@ -379,14 +375,18 @@ class WDAMacServer {
           intervalMs: 1000,
         });
       } catch (e) {
-        if (this.process && this.process.isRunning) {
+        if (this.process?.isRunning) {
           // avoid "frozen" processes,
           await this.process.kill();
         }
         if (/Condition unmet/.test(e.message)) {
-          throw new Error(`Mac2Driver server is not listening within ${this.serverStartupTimeoutMs}ms timeout. ` +
+          const msg = this.isProxyingToRemoteServer
+            ? `No response from '${scheme}://${server}:${port}${path}' within ${this.serverStartupTimeoutMs}ms timeout.` +
+            `Please make sure the remote server is running and accessible by Appium`
+            : `Mac2Driver server is not listening within ${this.serverStartupTimeoutMs}ms timeout. ` +
             `Try to increase the value of 'serverStartupTimeout' capability, check the server logs ` +
-            `and make sure the ${XCODEBUILD} host process could be started manually from a terminal`);
+            `and make sure the ${XCODEBUILD} host process could be started manually from a terminal`;
+          throw new Error(msg);
         }
         throw e;
       }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -266,10 +266,6 @@ class WDAMacServer {
     this.isProxyingToRemoteServer = false;
   }
 
-  get isRunning () {
-    return !!(this.process?.isRunning);
-  }
-
   /**
    * Returns true if WDAMacServer should prepare proxy instance
    *
@@ -411,7 +407,7 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    if (!this.isProxyingToRemoteServer && !this.isRunning) {
+    if (!this.isProxyingToRemoteServer && !(this.process?.isRunning)) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import path from 'path';
+import url from 'url';
 import { JWProxy, errors } from 'appium-base-driver';
 import { fs, logger, util, timing, mkdirp } from 'appium-support';
 import { SubProcess, exec } from 'teen_process';
@@ -140,6 +141,11 @@ class WDAMacProcess {
   async init (opts = {}) {
     if (this.isRunning) {
       return false;
+    }
+
+    if (_.isString(opts.webDriverAgentUrl)) {
+      // Skip to init WDA server
+      return true;
     }
 
     this.showServerLogs = opts.showServerLogs ?? this.showServerLogs;
@@ -283,14 +289,23 @@ class WDAMacServer {
     const wasProcessInitNecessary = await this.process.init(caps);
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
+      let serverHost = HOST;
+      let serverPort = this.process.port;
+      let basePath = '';
+      if (_.isString(caps.webDriverAgentUrl)) {
+        const {hostname, port, pathname} = url.parse(caps.webDriverAgentUrl);
+        serverHost = hostname ?? HOST;
+        serverPort = port ?? DEFAULT_SYSTEM_PORT;
+        basePath = pathname === '/' ? '' : pathname;
+      }
       this.proxy = new WDAMacProxy({
-        server: HOST,
-        port: this.process.port,
-        base: '',
+        server: serverHost,
+        port: serverPort,
+        base: basePath,
         keepAlive: true,
       });
       this.proxy.didProcessExit = false;
-      this.process.proc.on('exit', () => {
+      this.process.proc?.on('exit', () => {
         this.proxy.didProcessExit = true;
       });
 
@@ -315,7 +330,7 @@ class WDAMacServer {
       const pid = this.process.pid;
       const childrenPids = await this.process.listChildrenPids();
       RUNNING_PROCESS_IDS.push(...childrenPids, pid);
-      this.process.proc.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
+      this.process.proc?.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
       log.info(`The host process is ready within ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
     } else {
       log.info('The host process has already been listening. Proceeding with session creation');

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -347,7 +347,7 @@ class WDAMacServer {
     if (this.isProxyingToRemoteServer) {
       wasProcessInitNecessary = false;
     } else {
-      if (!this.process) { this.process = new WDAMacProcess(); }
+      if (!this.process?.isRunning) { this.process = new WDAMacProcess(); }
       wasProcessInitNecessary = await this.process.init(caps);
     }
 
@@ -411,8 +411,7 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    // TODO: update
-    if (!this.isRunning && !this.isProxyingToRemoteServer) {
+    if (!this.isProxyingToRemoteServer && !this.isRunning) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -258,12 +258,12 @@ class WDAMacProcess {
 
 class WDAMacServer {
   constructor () {
-    this.process = new WDAMacProcess();
+    this.process = null;
     this.serverStartupTimeoutMs = STARTUP_TIMEOUT_MS;
     this.proxy = null;
 
     // To handle if the WDAMac server is proxying requests to a remote WDAMac app instance
-    this.isProxyingRemoteWDAMac = false;
+    this.isProxyingToRemoteServer = false;
   }
 
   get isRunning () {
@@ -271,7 +271,7 @@ class WDAMacServer {
   }
 
   async isProxyReady (throwOnExit = true) {
-    if (!this.proxy) {
+    if (!this.proxy && !this.isProxyingToRemoteServer) {
       return false;
     }
 
@@ -305,7 +305,7 @@ class WDAMacServer {
   parseProxyProperties (wdaUrl) {
     let scheme = 'http';
     if (!wdaUrl) {
-      return {scheme, server: DEFAULT_SYSTEM_HOST, port: this.process.port, path: ''};
+      return {scheme, server: DEFAULT_SYSTEM_HOST, port: this.process?.port || DEFAULT_SYSTEM_PORT, path: ''};
     }
 
     const {protocol, hostname, port, pathname} = url.parse(wdaUrl);
@@ -322,8 +322,17 @@ class WDAMacServer {
 
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
-    this.isProxyingRemoteWDAMac = !!caps.webDriverAgentMacUrl;
-    const wasProcessInitNecessary = this.isProxyingRemoteWDAMac ? false : await this.process.init(caps);
+
+    this.isProxyingToRemoteServer = !!caps.webDriverAgentMacUrl;
+
+    // TODO: simplify with this.isProxyReady
+    let wasProcessInitNecessary;
+    if (!this.isProxyingToRemoteServer) {
+      this.process = new WDAMacProcess();
+      wasProcessInitNecessary = await this.process.init(caps);
+    } else {
+      wasProcessInitNecessary = false;
+    }
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
       const {scheme, server, port, path} = this.parseProxyProperties(caps.webDriverAgentMacUrl);
@@ -336,9 +345,11 @@ class WDAMacServer {
       });
       this.proxy.didProcessExit = false;
 
-      this.process.proc?.on('exit', () => {
-        this.proxy.didProcessExit = true;
-      });
+      if (this.process) {
+        this.process.proc.on('exit', () => {
+          this.proxy.didProcessExit = true;
+        });
+      }
 
       const timer = new timing.Timer().start();
       try {
@@ -347,7 +358,7 @@ class WDAMacServer {
           intervalMs: 1000,
         });
       } catch (e) {
-        if (this.process.isRunning) {
+        if (this.process && this.process.isRunning) {
           // avoid "frozen" processes,
           await this.process.kill();
         }
@@ -359,7 +370,7 @@ class WDAMacServer {
         throw e;
       }
 
-      if (!caps.webDriverAgentMacUrl) {
+      if (this.process) {
         const pid = this.process.pid;
         const childrenPids = await this.process.listChildrenPids();
         RUNNING_PROCESS_IDS.push(...childrenPids, pid);
@@ -379,7 +390,8 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    if (!this.isRunning && !this.isProxyingRemoteWDAMac) {
+    // TODO: update
+    if (!this.isRunning && !this.isProxyingToRemoteServer) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }
@@ -392,10 +404,11 @@ class WDAMacServer {
       }
     }
 
-    if (this.isProxyingRemoteWDAMac) {
+    // TODO: do this.isProxyReady everytime
+    if (this.isProxyingToRemoteServer) {
       // Should check `isProxyReady` everytime for the remote WDAMac
       this.proxy = null;
-      this.isProxyingRemoteWDAMac = false;
+      this.isProxyingToRemoteServer = false;
     }
   }
 }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -270,8 +270,23 @@ class WDAMacServer {
     return !!(this.process?.isRunning);
   }
 
+  /**
+   * Returns true if the proxy instance is ready
+   */
+  shouldPrepareProxy () {
+    if (this.isProxyingToRemoteServer) {
+      return true;
+    }
+
+    if (!this.proxy) {
+      return true;
+    }
+
+    return false;
+  }
+
   async isProxyReady (throwOnExit = true) {
-    if (!this.proxy && !this.isProxyingToRemoteServer) {
+    if (!this.proxy) {
       return false;
     }
 
@@ -297,18 +312,23 @@ class WDAMacServer {
    */
 
   /**
-   * Returns information about proxy information which WDAMacServer proxy to.
+   * Returns proxy information where WDAMacServer proxy to.
    *
-   * @param {?string} wdaUrl - The URL for WDAMacServer app to proxy requests to.
+   * @param {Object} caps - The capabilities in the session.
    * @return {ProxyProperties}
    */
-  parseProxyProperties (wdaUrl) {
+  parseProxyProperties (caps) {
     let scheme = 'http';
-    if (!wdaUrl) {
-      return {scheme, server: DEFAULT_SYSTEM_HOST, port: this.process?.port || DEFAULT_SYSTEM_PORT, path: ''};
+    if (!caps.webDriverAgentMacUrl) {
+      return {
+        scheme,
+        server: (this.process?.host ?? caps.systemHost) ?? DEFAULT_SYSTEM_HOST,
+        port: (this.process?.port ?? caps.systemPort) ?? DEFAULT_SYSTEM_PORT,
+        path: ''
+      };
     }
 
-    const {protocol, hostname, port, pathname} = url.parse(wdaUrl);
+    const {protocol, hostname, port, pathname} = url.parse(caps.webDriverAgentMacUrl);
     if (_.isString(protocol)) {
       scheme = protocol.split(':')[0];
     }
@@ -334,8 +354,8 @@ class WDAMacServer {
       wasProcessInitNecessary = false;
     }
 
-    if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
-      const {scheme, server, port, path} = this.parseProxyProperties(caps.webDriverAgentMacUrl);
+    if (wasProcessInitNecessary || this.shouldPrepareProxy()) {
+      const {scheme, server, port, path} = this.parseProxyProperties(caps);
       this.proxy = new WDAMacProxy({
         scheme,
         server,
@@ -402,13 +422,6 @@ class WDAMacServer {
       } catch (e) {
         log.info(`Mac2Driver session cannot be deleted. Original error: ${e.message}`);
       }
-    }
-
-    // TODO: do this.isProxyReady everytime
-    if (this.isProxyingToRemoteServer) {
-      // Should check `isProxyReady` everytime for the remote WDAMac
-      this.proxy = null;
-      this.isProxyingToRemoteServer = false;
     }
   }
 }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -143,7 +143,7 @@ class WDAMacProcess {
       return false;
     }
 
-    if (_.isString(opts.WebDriverAgentMacUrl)) {
+    if (_.isString(opts.webDriverAgentMacUrl)) {
       // Skip to init WDA server
       return true;
     }
@@ -302,8 +302,8 @@ class WDAMacServer {
    */
   getProxyToInfo (caps) {
     let scheme = 'http';
-    if (_.isString(caps.WebDriverAgentMacUrl)) {
-      const {protocol, hostname, port, pathname} = url.parse(caps.WebDriverAgentMacUrl);
+    if (_.isString(caps.webDriverAgentMacUrl)) {
+      const {protocol, hostname, port, pathname} = url.parse(caps.webDriverAgentMacUrl);
       if (_.isString(protocol)) {
         scheme = protocol.split(':')[0];
       }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -266,19 +266,6 @@ class WDAMacServer {
     this.isProxyingToRemoteServer = false;
   }
 
-  /**
-   * Returns true if WDAMacServer should prepare proxy instance
-   *
-   * @return {boolean}
-   */
-  shouldPrepareProxy () {
-    if (this.isProxyingToRemoteServer || !this.proxy) {
-      return true;
-    }
-
-    return false;
-  }
-
   async isProxyReady (throwOnExit = true) {
     if (!this.proxy) {
       return false;
@@ -347,7 +334,7 @@ class WDAMacServer {
       wasProcessInitNecessary = await this.process.init(caps);
     }
 
-    if (wasProcessInitNecessary || this.shouldPrepareProxy()) {
+    if (wasProcessInitNecessary || this.isProxyingToRemoteServer || !this.proxy) {
       const {scheme, server, port, path} = this.parseProxyProperties(caps);
       this.proxy = new WDAMacProxy({
         scheme,

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -143,7 +143,7 @@ class WDAMacProcess {
       return false;
     }
 
-    if (_.isString(opts.webDriverAgentUrl)) {
+    if (_.isString(opts.WebDriverAgentMacUrl)) {
       // Skip to init WDA server
       return true;
     }
@@ -284,24 +284,35 @@ class WDAMacServer {
     }
   }
 
+  _get_proxy_preference (caps) {
+    let scheme = 'http';
+    if (_.isString(caps.WebDriverAgentMacUrl)) {
+      const {protocol, hostname, port, pathname} = url.parse(caps.WebDriverAgentMacUrl);
+      if (_.isString(protocol)) {
+        scheme = protocol.split(':')[0];
+      }
+      return {
+        scheme,
+        host: hostname ?? HOST,
+        port: _.isNull(port) ? DEFAULT_SYSTEM_PORT : _.parseInt(port),
+        path: pathname === '/' ? '' : pathname
+      };
+    }
+
+    return {scheme, host: HOST, port: this.process.port, path: ''};
+  }
+
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
     const wasProcessInitNecessary = await this.process.init(caps);
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
-      let serverHost = HOST;
-      let serverPort = this.process.port;
-      let basePath = '';
-      if (_.isString(caps.webDriverAgentUrl)) {
-        const {hostname, port, pathname} = url.parse(caps.webDriverAgentUrl);
-        serverHost = hostname ?? HOST;
-        serverPort = port ?? DEFAULT_SYSTEM_PORT;
-        basePath = pathname === '/' ? '' : pathname;
-      }
+      const {scheme, server, port, path} = this._get_proxy_preference(caps);
       this.proxy = new WDAMacProxy({
-        server: serverHost,
-        port: serverPort,
-        base: basePath,
+        scheme,
+        server,
+        port,
+        base: path,
         keepAlive: true,
       });
       this.proxy.didProcessExit = false;

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -364,9 +364,7 @@ class WDAMacServer {
         throw e;
       }
 
-      if (caps.webDriverAgentMacUrl) {
-        log.info(`Proxying requests to ${scheme}://${server}:${port}${path}`);
-      } else {
+      if (!caps.webDriverAgentMacUrl) {
         const pid = this.process.pid;
         const childrenPids = await this.process.listChildrenPids();
         RUNNING_PROCESS_IDS.push(...childrenPids, pid);
@@ -398,8 +396,6 @@ class WDAMacServer {
         log.info(`Mac2Driver session cannot be deleted. Original error: ${e.message}`);
       }
     }
-
-    this.proxy = null;
   }
 }
 

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -268,7 +268,7 @@ class WDAMacServer {
   }
 
   /**
-   * Returns true if the WDAMac server is proxying requests
+   * Return true if the WDAMac server is proxying requests
    *
    * @return {boolean}
    */

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -330,17 +330,6 @@ class WDAMacServer {
     };
   }
 
-  async getRunningProcesses () {
-    if (!this.process) {
-      return [];
-    }
-
-    const pid = this.process.pid;
-    const childrenPids = await this.process.listChildrenPids();
-
-    return [...childrenPids, pid];
-  }
-
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
 
@@ -349,12 +338,8 @@ class WDAMacServer {
     let wasProcessInitNecessary;
     if (this.isProxyingToRemoteServer) {
       if (this.process) {
-        // Killing previous processes
-        // TODO: Check below process later
-        // await cleanupObsoleteProcesses();
-        const pids = await this.getRunningProcesses();
-        await this.process.kill();
-        _.pullAll(RUNNING_PROCESS_IDS, pids);
+        await this.process.stop();
+        await cleanupObsoleteProcesses();
         this.process = null;
       }
 
@@ -407,8 +392,10 @@ class WDAMacServer {
       }
 
       if (this.process) {
-        RUNNING_PROCESS_IDS.push(await this.getRunningProcesses());
-        this.process.proc.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, this.process.pid));
+        const pid = this.process.pid;
+        const childrenPids = await this.process.listChildrenPids();
+        RUNNING_PROCESS_IDS.push(...childrenPids, pid);
+        this.process.proc.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
         log.info(`The host process is ready within ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
       }
     } else {

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -284,7 +284,23 @@ class WDAMacServer {
     }
   }
 
-  _get_proxy_preference (caps) {
+
+  /**
+   * @typedef {Object} ProxyToInfo
+   *
+   * @property {string} scheme - The scheme proxy to.
+   * @property {string} host - The host name proxy to.
+   * @property {number} port - The port number proxy to.
+   * @property {string} path - The path proxy to.
+   */
+
+  /**
+   * Returns information about proxy information which WDAMacServer proxy to.
+   *
+   * @param {Object} caps - The capabilities provided by a client
+   * @return {ProxyToInfo}
+   */
+  getProxyToInfo (caps) {
     let scheme = 'http';
     if (_.isString(caps.WebDriverAgentMacUrl)) {
       const {protocol, hostname, port, pathname} = url.parse(caps.WebDriverAgentMacUrl);
@@ -307,7 +323,7 @@ class WDAMacServer {
     const wasProcessInitNecessary = await this.process.init(caps);
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
-      const {scheme, server, port, path} = this._get_proxy_preference(caps);
+      const {scheme, server, port, path} = this.getProxyToInfo(caps);
       this.proxy = new WDAMacProxy({
         scheme,
         server,

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -261,19 +261,13 @@ class WDAMacServer {
     this.process = new WDAMacProcess();
     this.serverStartupTimeoutMs = STARTUP_TIMEOUT_MS;
     this.proxy = null;
+
+    // To handle if the WDAMac server is proxying requests to a remote WDAMac app instance
+    this.isProxyingRemoteWDAMac = false;
   }
 
   get isRunning () {
     return !!(this.process?.isRunning);
-  }
-
-  /**
-   * Return true if the WDAMac server is proxying requests
-   *
-   * @return {boolean}
-   */
-  get isProxying () {
-    return !!this.proxy;
   }
 
   async isProxyReady (throwOnExit = true) {
@@ -328,7 +322,8 @@ class WDAMacServer {
 
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
-    const wasProcessInitNecessary = !caps.webDriverAgentMacUrl ? await this.process.init(caps) : true;
+    this.isProxyingRemoteWDAMac = !!caps.webDriverAgentMacUrl;
+    const wasProcessInitNecessary = this.isProxyingRemoteWDAMac ? false : await this.process.init(caps);
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
       const {scheme, server, port, path} = this.parseProxyProperties(caps.webDriverAgentMacUrl);
@@ -384,7 +379,7 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    if (!this.isRunning && !this.isProxying) {
+    if (!this.isRunning && !this.isProxyingRemoteWDAMac) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }
@@ -395,6 +390,12 @@ class WDAMacServer {
       } catch (e) {
         log.info(`Mac2Driver session cannot be deleted. Original error: ${e.message}`);
       }
+    }
+
+    if (this.isProxyingRemoteWDAMac) {
+      // Should check `isProxyReady` everytime for the remote WDAMac
+      this.proxy = null;
+      this.isProxyingRemoteWDAMac = false;
     }
   }
 }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -341,9 +341,12 @@ class WDAMacServer {
     if (this.isProxyingToRemoteServer) {
       if (this.process) {
         // Killing previous processes
+        // TODO: Check below process later
+        // await cleanupObsoleteProcesses();
         const pids = await this.getRunningProcesses();
         await this.process.kill();
         _.pullAll(RUNNING_PROCESS_IDS, pids);
+        this.process = null;
       }
 
       wasProcessInitNecessary = false;

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -306,7 +306,7 @@ class WDAMacServer {
    */
   parseProxyProperties (wdaUrl) {
     let scheme = 'http';
-    if (!_.isString(wdaUrl)) {
+    if (!wdaUrl) {
       return {scheme, server: DEFAULT_SYSTEM_HOST, port: this.process.port, path: ''};
     }
 

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -347,13 +347,12 @@ class WDAMacServer {
 
     this.isProxyingToRemoteServer = !!caps.webDriverAgentMacUrl;
 
-    // TODO: simplify with this.isProxyReady
     let wasProcessInitNecessary;
-    if (!this.isProxyingToRemoteServer) {
+    if (this.isProxyingToRemoteServer) {
+      wasProcessInitNecessary = false;
+    } else {
       this.process = new WDAMacProcess();
       wasProcessInitNecessary = await this.process.init(caps);
-    } else {
-      wasProcessInitNecessary = false;
     }
 
     if (wasProcessInitNecessary || this.shouldPrepareProxy()) {

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -330,7 +330,9 @@ class WDAMacServer {
     if (this.isProxyingToRemoteServer) {
       wasProcessInitNecessary = false;
     } else {
-      if (!this.process?.isRunning) { this.process = new WDAMacProcess(); }
+      if (!this.process) {
+        this.process = new WDAMacProcess();
+      }
       wasProcessInitNecessary = await this.process.init(caps);
     }
 
@@ -394,7 +396,7 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    if (!this.isProxyingToRemoteServer && !(this.process?.isRunning)) {
+    if (!this.isProxyingToRemoteServer || !(this.process?.isRunning)) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -321,6 +321,17 @@ class WDAMacServer {
     };
   }
 
+  async getRunningProcesses () {
+    if (!this.process) {
+      return [];
+    }
+
+    const pid = this.process.pid;
+    const childrenPids = await this.process.listChildrenPids();
+
+    return [...childrenPids, pid];
+  }
+
   async startSession (caps) {
     this.serverStartupTimeoutMs = caps.serverStartupTimeout ?? this.serverStartupTimeoutMs;
 
@@ -328,6 +339,13 @@ class WDAMacServer {
 
     let wasProcessInitNecessary;
     if (this.isProxyingToRemoteServer) {
+      if (this.process) {
+        // Killing previous processes
+        const pids = await this.getRunningProcesses();
+        await this.process.kill();
+        _.pullAll(RUNNING_PROCESS_IDS, pids);
+      }
+
       wasProcessInitNecessary = false;
     } else {
       if (!this.process) {
@@ -377,10 +395,8 @@ class WDAMacServer {
       }
 
       if (this.process) {
-        const pid = this.process.pid;
-        const childrenPids = await this.process.listChildrenPids();
-        RUNNING_PROCESS_IDS.push(...childrenPids, pid);
-        this.process.proc.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, pid));
+        RUNNING_PROCESS_IDS.push(await this.getRunningProcesses());
+        this.process.proc.on('exit', () => void _.pull(RUNNING_PROCESS_IDS, this.process.pid));
         log.info(`The host process is ready within ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
       }
     } else {
@@ -396,7 +412,7 @@ class WDAMacServer {
   }
 
   async stopSession () {
-    if (!this.isProxyingToRemoteServer || !(this.process?.isRunning)) {
+    if (!this.isProxyingToRemoteServer && !(this.process?.isRunning)) {
       log.info(`Mac2Driver session cannot be stopped, because the server is not running`);
       return;
     }

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -1,9 +1,27 @@
-import Mac2Driver from '../..';
-import chai from 'chai';
-const should = chai.should();
+import WDA_MAC_SERVER from '../../lib/wda-mac';
 
-describe('Mac2Driver', function () {
-  it('should exist', function () {
-    should.exist(Mac2Driver);
+describe('WDAMacServer', function () {
+  describe('_get_proxy_preference', function () {
+    it('should default', function () {
+      WDA_MAC_SERVER._get_proxy_preference({}).should.eql(
+        {scheme: 'http', host: '127.0.0.1', port: 10100, path: ''}
+      );
+    });
+
+    it('should follow WebDriverAgentMacUrl', function () {
+      WDA_MAC_SERVER._get_proxy_preference({
+        WebDriverAgentMacUrl: 'http://customhost:9999'
+      }).should.eql(
+        {scheme: 'http', host: 'customhost', port: 9999, path: ''}
+      );
+    });
+
+    it('should follow WebDriverAgentMacUrl with custom path', function () {
+      WDA_MAC_SERVER._get_proxy_preference({
+        WebDriverAgentMacUrl: 'https://customhost/path'
+      }).should.eql(
+        {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}
+      );
+    });
   });
 });

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -1,27 +1,9 @@
-import WDA_MAC_SERVER from '../../lib/wda-mac';
+import Mac2Driver from '../..';
+import chai from 'chai';
+const should = chai.should();
 
-describe('WDAMacServer', function () {
-  describe('_get_proxy_preference', function () {
-    it('should default', function () {
-      WDA_MAC_SERVER._get_proxy_preference({}).should.eql(
-        {scheme: 'http', host: '127.0.0.1', port: 10100, path: ''}
-      );
-    });
-
-    it('should follow WebDriverAgentMacUrl', function () {
-      WDA_MAC_SERVER._get_proxy_preference({
-        WebDriverAgentMacUrl: 'http://customhost:9999'
-      }).should.eql(
-        {scheme: 'http', host: 'customhost', port: 9999, path: ''}
-      );
-    });
-
-    it('should follow WebDriverAgentMacUrl with custom path', function () {
-      WDA_MAC_SERVER._get_proxy_preference({
-        WebDriverAgentMacUrl: 'https://customhost/path'
-      }).should.eql(
-        {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}
-      );
-    });
+describe('Mac2Driver', function () {
+  it('should exist', function () {
+    should.exist(Mac2Driver);
   });
 });

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,0 +1,9 @@
+import Mac2Driver from '../..';
+import chai from 'chai';
+const should = chai.should();
+
+describe('Mac2Driver', function () {
+  it('should exist', function () {
+    should.exist(Mac2Driver);
+  });
+});

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,25 +1,21 @@
 import WDA_MAC_SERVER from '../../lib/wda-mac';
 
 describe('WDAMacServer', function () {
-  describe('getProxyToInfo', function () {
+  describe('parseProxyProperties', function () {
     it('should default', function () {
-      WDA_MAC_SERVER.getProxyToInfo({}).should.eql(
+      WDA_MAC_SERVER.parseProxyProperties(undefined).should.eql(
         {scheme: 'http', host: '127.0.0.1', port: 10100, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl', function () {
-      WDA_MAC_SERVER.getProxyToInfo({
-        webDriverAgentMacUrl: 'http://customhost:9999'
-      }).should.eql(
+      WDA_MAC_SERVER.parseProxyProperties('http://customhost:9999').should.eql(
         {scheme: 'http', host: 'customhost', port: 9999, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl with custom path', function () {
-      WDA_MAC_SERVER.getProxyToInfo({
-        webDriverAgentMacUrl: 'https://customhost/path'
-      }).should.eql(
+      WDA_MAC_SERVER.parseProxyProperties('https://customhost/path').should.eql(
         {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}
       );
     });

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,15 +1,15 @@
 import WDA_MAC_SERVER from '../../lib/wda-mac';
 
 describe('WDAMacServer', function () {
-  describe('_get_proxy_preference', function () {
+  describe('getProxyToInfo', function () {
     it('should default', function () {
-      WDA_MAC_SERVER._get_proxy_preference({}).should.eql(
+      WDA_MAC_SERVER.getProxyToInfo({}).should.eql(
         {scheme: 'http', host: '127.0.0.1', port: 10100, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl', function () {
-      WDA_MAC_SERVER._get_proxy_preference({
+      WDA_MAC_SERVER.getProxyToInfo({
         WebDriverAgentMacUrl: 'http://customhost:9999'
       }).should.eql(
         {scheme: 'http', host: 'customhost', port: 9999, path: ''}
@@ -17,7 +17,7 @@ describe('WDAMacServer', function () {
     });
 
     it('should follow WebDriverAgentMacUrl with custom path', function () {
-      WDA_MAC_SERVER._get_proxy_preference({
+      WDA_MAC_SERVER.getProxyToInfo({
         WebDriverAgentMacUrl: 'https://customhost/path'
       }).should.eql(
         {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -4,19 +4,19 @@ describe('WDAMacServer', function () {
   describe('parseProxyProperties', function () {
     it('should default', function () {
       WDA_MAC_SERVER.parseProxyProperties(undefined).should.eql(
-        {scheme: 'http', host: '127.0.0.1', port: 10100, path: ''}
+        {scheme: 'http', server: '127.0.0.1', port: 10100, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl', function () {
       WDA_MAC_SERVER.parseProxyProperties('http://customhost:9999').should.eql(
-        {scheme: 'http', host: 'customhost', port: 9999, path: ''}
+        {scheme: 'http', server: 'customhost', port: 9999, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl with custom path', function () {
       WDA_MAC_SERVER.parseProxyProperties('https://customhost/path').should.eql(
-        {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}
+        {scheme: 'https', server: 'customhost', port: 10100, path: '/path'}
       );
     });
   });

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,36 +1,6 @@
 import WDA_MAC_SERVER from '../../lib/wda-mac';
 
 describe('WDAMacServer', function () {
-  describe('shouldPrepareProxy', function () {
-    beforeEach(function () {
-      WDA_MAC_SERVER.isProxyingToRemoteServer = false;
-      WDA_MAC_SERVER.proxy = null;
-    });
-
-    it('should do with isProxyingToRemoteServer true', function () {
-      WDA_MAC_SERVER.isProxyingToRemoteServer = true;
-      WDA_MAC_SERVER.proxy = null;
-      WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
-    });
-
-    it('should do with isProxyingToRemoteServer true and it already has proxy', function () {
-      WDA_MAC_SERVER.isProxyingToRemoteServer = true;
-      WDA_MAC_SERVER.proxy = Object();
-      WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
-    });
-
-    it('should do with no proxy instancce', function () {
-      WDA_MAC_SERVER.isProxyingToRemoteServer = false;
-      WDA_MAC_SERVER.proxy = null;
-      WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
-    });
-
-    it('should not do since it has proxy instance WebDriverAgentMacUrl with custom path', function () {
-      WDA_MAC_SERVER.isProxyingToRemoteServer = false;
-      WDA_MAC_SERVER.proxy = Object();
-      WDA_MAC_SERVER.shouldPrepareProxy().should.be.false;
-    });
-  });
   describe('parseProxyProperties', function () {
     it('should default', function () {
       WDA_MAC_SERVER.parseProxyProperties({}).should.eql(

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,21 +1,41 @@
 import WDA_MAC_SERVER from '../../lib/wda-mac';
 
 describe('WDAMacServer', function () {
+  describe('shouldPrepareProxy', function () {
+    beforeEach(function () {
+      WDA_MAC_SERVER.isProxyingToRemoteServer = false;
+      WDA_MAC_SERVER.proxy = null;
+    });
+
+    it('should do with isProxyingToRemoteServer true', function () {
+      WDA_MAC_SERVER.isProxyingToRemoteServer = true;
+      WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
+    });
+
+    it('should do with no proxy instancce', function () {
+      WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
+    });
+
+    it('should not do since it has proxy instance WebDriverAgentMacUrl with custom path', function () {
+      WDA_MAC_SERVER.proxy = Object();
+      WDA_MAC_SERVER.shouldPrepareProxy().should.be.false;
+    });
+  });
   describe('parseProxyProperties', function () {
     it('should default', function () {
-      WDA_MAC_SERVER.parseProxyProperties(undefined).should.eql(
+      WDA_MAC_SERVER.parseProxyProperties({}).should.eql(
         {scheme: 'http', server: '127.0.0.1', port: 10100, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl', function () {
-      WDA_MAC_SERVER.parseProxyProperties('http://customhost:9999').should.eql(
+      WDA_MAC_SERVER.parseProxyProperties({ webDriverAgentMacUrl: 'http://customhost:9999' }).should.eql(
         {scheme: 'http', server: 'customhost', port: 9999, path: ''}
       );
     });
 
     it('should follow WebDriverAgentMacUrl with custom path', function () {
-      WDA_MAC_SERVER.parseProxyProperties('https://customhost/path').should.eql(
+      WDA_MAC_SERVER.parseProxyProperties({ webDriverAgentMacUrl: 'https://customhost/path' }).should.eql(
         {scheme: 'https', server: 'customhost', port: 10100, path: '/path'}
       );
     });

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -10,7 +10,7 @@ describe('WDAMacServer', function () {
 
     it('should follow WebDriverAgentMacUrl', function () {
       WDA_MAC_SERVER.getProxyToInfo({
-        WebDriverAgentMacUrl: 'http://customhost:9999'
+        webDriverAgentMacUrl: 'http://customhost:9999'
       }).should.eql(
         {scheme: 'http', host: 'customhost', port: 9999, path: ''}
       );
@@ -18,7 +18,7 @@ describe('WDAMacServer', function () {
 
     it('should follow WebDriverAgentMacUrl with custom path', function () {
       WDA_MAC_SERVER.getProxyToInfo({
-        WebDriverAgentMacUrl: 'https://customhost/path'
+        webDriverAgentMacUrl: 'https://customhost/path'
       }).should.eql(
         {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}
       );

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,4 +1,8 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import WDA_MAC_SERVER from '../../lib/wda-mac';
+
+chai.use(chaiAsPromised);
 
 describe('WDAMacServer', function () {
   describe('parseProxyProperties', function () {
@@ -18,6 +22,14 @@ describe('WDAMacServer', function () {
       WDA_MAC_SERVER.parseProxyProperties({ webDriverAgentMacUrl: 'https://customhost/path' }).should.eql(
         {scheme: 'https', server: 'customhost', port: 10100, path: '/path'}
       );
+    });
+
+    it('should follow WebDriverAgentMacUrl with invalid url', function () {
+      try {
+        WDA_MAC_SERVER.parseProxyProperties({ webDriverAgentMacUrl: 'invalid url' });
+      } catch (e) {
+        e.message.should.contain('is invalid');
+      }
     });
   });
 });

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -1,9 +1,27 @@
-import Mac2Driver from '../..';
-import chai from 'chai';
-const should = chai.should();
+import WDA_MAC_SERVER from '../../lib/wda-mac';
 
-describe('Mac2Driver', function () {
-  it('should exist', function () {
-    should.exist(Mac2Driver);
+describe('WDAMacServer', function () {
+  describe('_get_proxy_preference', function () {
+    it('should default', function () {
+      WDA_MAC_SERVER._get_proxy_preference({}).should.eql(
+        {scheme: 'http', host: '127.0.0.1', port: 10100, path: ''}
+      );
+    });
+
+    it('should follow WebDriverAgentMacUrl', function () {
+      WDA_MAC_SERVER._get_proxy_preference({
+        WebDriverAgentMacUrl: 'http://customhost:9999'
+      }).should.eql(
+        {scheme: 'http', host: 'customhost', port: 9999, path: ''}
+      );
+    });
+
+    it('should follow WebDriverAgentMacUrl with custom path', function () {
+      WDA_MAC_SERVER._get_proxy_preference({
+        WebDriverAgentMacUrl: 'https://customhost/path'
+      }).should.eql(
+        {scheme: 'https', host: 'customhost', port: 10100, path: '/path'}
+      );
+    });
   });
 });

--- a/test/unit/wda-mac-specs.js
+++ b/test/unit/wda-mac-specs.js
@@ -9,14 +9,24 @@ describe('WDAMacServer', function () {
 
     it('should do with isProxyingToRemoteServer true', function () {
       WDA_MAC_SERVER.isProxyingToRemoteServer = true;
+      WDA_MAC_SERVER.proxy = null;
+      WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
+    });
+
+    it('should do with isProxyingToRemoteServer true and it already has proxy', function () {
+      WDA_MAC_SERVER.isProxyingToRemoteServer = true;
+      WDA_MAC_SERVER.proxy = Object();
       WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
     });
 
     it('should do with no proxy instancce', function () {
+      WDA_MAC_SERVER.isProxyingToRemoteServer = false;
+      WDA_MAC_SERVER.proxy = null;
       WDA_MAC_SERVER.shouldPrepareProxy().should.be.true;
     });
 
     it('should not do since it has proxy instance WebDriverAgentMacUrl with custom path', function () {
+      WDA_MAC_SERVER.isProxyingToRemoteServer = false;
       WDA_MAC_SERVER.proxy = Object();
       WDA_MAC_SERVER.shouldPrepareProxy().should.be.false;
     });


### PR DESCRIPTION
`webDriverAgentMacUrl` works as same as iOS/webDriverAgentUrl.

This allows us to launch an appium server on a machine and handle mac2 driver on another macOS machine.
(Mainly I want this capability to develop mac2 driver on my environment so far)