### PR TITLE
chore: Set server host to 127.0.0.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Capability Name | Description
 --- | ---
 platformName | Should be set to `mac`
 automationName | Must always be set to `mac2`. Values of automationName are compared case-insensitively.
-appium:systemPort | The number of the port for the driver to listen on. If not provided then Appium will use the default port `10100`.
+appium:systemPort | The number of the port for the internal server to listen on. If not provided then Mac2Driver will use the default port `10100`.
+appium:systemHost | The name of the host for the internal server to listen on. If not provided then Mac2Driver will use the default host address `127.0.0.1`. You could set it to `0.0.0.0` to make the server listening on all available network interfaces. It is also possible to set the particular interface name, for example `en1`.
 appium:showServerLogs | Set it to `true` in order to include xcodebuild output to the Appium server log. `false` by default.
 appium:bootstrapRoot | The full path to `WebDriverAgentMac` root folder where Xcode project of the server sources lives. By default this project is located in the same folder where the corresponding driver Node.js module lives.
 appium:serverStartupTimeout | The number of milliseconds to wait util the WebDriverAgentMac project is built and started. `120000` by default

--- a/WebDriverAgentMac/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Routing/FBWebServer.m
@@ -78,6 +78,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 {
   self.server = [[RoutingHTTPServer alloc] init];
   [self.server setRouteQueue:dispatch_get_main_queue()];
+  [self.server setInterface:FBConfiguration.sharedConfiguration.serverInterface];
   [self.server setDefaultHeader:@"Server" value:@"WebDriverAgent/1.0"];
   [self.server setDefaultHeader:@"Access-Control-Allow-Origin" value:@"*"];
   [self.server setDefaultHeader:@"Access-Control-Allow-Headers" value:@"Content-Type, X-Requested-With"];

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -33,6 +33,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSRange bindingPortRange;
 
 /**
+ * What interface the server is listening on.
+ * nil causes the server to listen on all available interfaces like en1, wifi etc.
+ *
+ * The interface may be specified by name (e.g. "en1" or "lo0") or by IP address (e.g. "192.168.4.34").
+ * You may also use the special strings "localhost" or "loopback" to specify that
+ * the socket only accepts connections from the local machine.
+ */
+@property (readonly, nullable) NSString *serverInterface;
+
+/**
  YES if verbose logging is enabled. NO otherwise.
  */
 @property (readonly) BOOL verboseLoggingEnabled;

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -75,10 +75,21 @@ static FBConfiguration *instance;
   // Existence of USE_PORT in the environment implies the port range is managed by the launching process.
   if (NSProcessInfo.processInfo.environment[@"USE_PORT"] &&
       [NSProcessInfo.processInfo.environment[@"USE_PORT"] length] > 0) {
-    return NSMakeRange([NSProcessInfo.processInfo.environment[@"USE_PORT"] integerValue] , 1);
+    return NSMakeRange([NSProcessInfo.processInfo.environment[@"USE_PORT"] integerValue], 1);
   }
 
   return NSMakeRange(DefaultStartingPort, DefaultPortRange);
+}
+
+- (NSString *)serverInterface
+{
+  // Existence of USE_HOST in the environment is managed by the launching process.
+  NSString *host = NSProcessInfo.processInfo.environment[@"USE_HOST"];
+  if (nil != host && host.length > 0) {
+    return [host isEqualToString:@"0.0.0.0"] ? nil : host;
+  }
+
+  return @"127.0.0.1";
 }
 
 - (BOOL)verboseLoggingEnabled

--- a/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -43,6 +43,11 @@
             value = "${USE_PORT}"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "USE_HOST"
+            value = "${USE_HOST}"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <Testables>
          <TestableReference

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -2,6 +2,9 @@ const desiredCapConstraints = {
   systemPort: {
     isNumber: true
   },
+  systemHost: {
+    isString: true
+  },
   showServerLogs: {
     isBoolean: true
   },

--- a/lib/wda-mac.js
+++ b/lib/wda-mac.js
@@ -10,7 +10,6 @@ import { listChildrenProcessIds } from './utils';
 
 const log = logger.getLogger('WebDriverAgentMac');
 
-const HOST = '127.0.0.1';
 const ROOT_DIR = path.basename(__dirname) === 'lib'
   ? path.resolve(__dirname, process.env.NO_PRECOMPILE ? '..' : '../..')
   : __dirname;
@@ -22,6 +21,7 @@ const DISABLE_STORE_ARG = 'COMPILER_INDEX_STORE_ENABLE=NO';
 const XCODEBUILD = 'xcodebuild';
 const STARTUP_TIMEOUT_MS = 120000;
 const DEFAULT_SYSTEM_PORT = 10100;
+const DEFAULT_SYSTEM_HOST = '127.0.0.1';
 const RUNNING_PROCESS_IDS = [];
 const RECENT_UPGRADE_TIMESTAMP_PATH = path.join('.appium',
   'webdriveragent_mac', 'upgrade.time');
@@ -72,6 +72,7 @@ class WDAMacProcess {
   constructor () {
     this.showServerLogs = false;
     this.port = DEFAULT_SYSTEM_PORT;
+    this.host = DEFAULT_SYSTEM_HOST;
     this.bootstrapRoot = WDA_ROOT;
     this.proc = null;
   }
@@ -144,6 +145,7 @@ class WDAMacProcess {
 
     this.showServerLogs = opts.showServerLogs ?? this.showServerLogs;
     this.port = opts.systemPort ?? this.port;
+    this.host = opts.systemHost ?? this.host;
     this.bootstrapRoot = opts.bootstrapRoot ?? this.bootstrapRoot;
 
     log.debug(`Using bootstrap root: ${this.bootstrapRoot}`);
@@ -180,10 +182,11 @@ class WDAMacProcess {
       }
     }
 
+    log.debug(`Using ${this.host} as server host`);
     log.debug(`Using port ${this.port}`);
-    const isPortBusy = (await checkPortStatus(this.port, HOST)) === 'open';
+    const isPortBusy = (await checkPortStatus(this.port, this.host)) === 'open';
     if (isPortBusy) {
-      throw new Error(`The port #${this.port} is busy. ` +
+      throw new Error(`The port #${this.port} at ${this.host} is busy. ` +
         `Consider setting 'systemPort' capability to another free port number and/or ` +
         `make sure the previous driver session(s) have been closed properly.`);
     }
@@ -196,6 +199,7 @@ class WDAMacProcess {
     ];
     const env = Object.assign({}, process.env, {
       USE_PORT: `${this.port}`,
+      USE_HOST: this.host,
     });
     this.proc = new SubProcess(xcodebuild, args, {
       cwd: this.bootstrapRoot,
@@ -284,7 +288,7 @@ class WDAMacServer {
 
     if (wasProcessInitNecessary || !(await this.isProxyReady(false))) {
       this.proxy = new WDAMacProxy({
-        server: HOST,
+        server: DEFAULT_SYSTEM_HOST,
         port: this.process.port,
         base: '',
         keepAlive: true,


### PR DESCRIPTION
Exposing server listener to all interfaces by default is not secure. This patch makes it configurable and changes the default server host to `127.0.0.1`