### PR TITLE
chore: Handle timeouts on Appium side

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -12,6 +12,8 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/elements?$')],
   ['POST', new RegExp('^/session/[^/]+/execute')],
   ['POST', new RegExp('^/session/[^/]+/execute/sync')],
+  ['GET', new RegExp('^/session/[^/]+/timeouts$')],
+  ['POST', new RegExp('^/session/[^/]+/timeouts$')],
 ];
 
 class Mac2Driver extends BaseDriver {


### PR DESCRIPTION
The server component simply ignores /timeouts API and that's by design