### PR TITLE
test: Add test example using absolute xpath with indexes

### DIFF
--- a/test/functional/find-e2e-specs.js
+++ b/test/functional/find-e2e-specs.js
@@ -80,6 +80,13 @@ describe('Mac2Driver - find elements', function () {
       '//XCUIElementTypePopUpButton[@value="Regular" and @label="type face"]');
     el.should.exist;
   });
+  
+  it('should find by absolute xpath', async function () {
+    // xpath index starts from 1
+    const el = await driver.elementByXPath(
+      '/XCUIElementTypeApplication[@title="TextEdit"]/XCUIElementTypeWindow[1]/XCUIElementTypeScrollView[1]');
+    el.should.exist;
+  });
 
   it('should find multiple by xpath', async function () {
     const els = await driver.elementsByXPath('//XCUIElementTypePopUpButton[@enabled="true"]');


### PR DESCRIPTION
I spent few hours trying to understand why xpaths from previous driver version were not working, apparently previous driver was using 0-based indexes in xpath. Hopefully this will same some time for others in the future