### PR TITLE
test: Add test example using absolute xpath with indexes

### DIFF
--- a/test/functional/find-e2e-specs.js
+++ b/test/functional/find-e2e-specs.js
@@ -81,6 +81,13 @@ describe('Mac2Driver - find elements', function () {
     el.should.exist;
   });
 
+  it('should find by absolute xpath', async function () {
+    // xpath index starts from 1
+    const el = await driver.elementByXPath(
+      '/XCUIElementTypeApplication[@title="TextEdit"]/XCUIElementTypeWindow[1]/XCUIElementTypeScrollView[1]');
+    el.should.exist;
+  });
+
   it('should find multiple by xpath', async function () {
     const els = await driver.elementsByXPath('//XCUIElementTypePopUpButton[@enabled="true"]');
     els.length.should.be.above(1);


### PR DESCRIPTION
I spent few hours trying to understand why xpaths from previous driver version were not working, apparently previous driver was using 0-based indexes in xpath. Hopefully this will same some time for others in the future