### PR TITLE
feat: Add support of swipe gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,15 @@ Perform click gesture on an element or by relative/absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | if `x` or `y` are unset | Unique identifier of the element to perform the click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-x | number | if `y` is set or `element` is unset | click X coordinate | 100
-y | number | if `y` is set or `element` is unset | click Y coordinate | 100
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | Unique identifier of the element to perform the click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+x | number | if `y` is set or `elementId` is unset | click X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | click Y coordinate | 100
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while click is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [click (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1500316-click?language=objc)
+- [click (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/1500677-click?language=objc)
 
 ### macos: clickAndHold
 
@@ -95,11 +100,16 @@ Perform long click gesture on an element or by relative/absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | if `x` or `y` are unset | Unique identifier of the element to perform the long click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-x | number | if `y` is set or `element` is unset | long click X coordinate | 100
-y | number | if `y` is set or `element` is unset | long click Y coordinate | 100
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | Unique identifier of the element to perform the long click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+x | number | if `y` is set or `elementId` is unset | long click X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | long click Y coordinate | 100
 duration | number | yes | The number of float seconds to hold the mouse button | 2.5
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while long click is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [pressForDuration: (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1618663-pressforduration?language=objc)
+- [pressForDuration: (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/1615002-pressforduration?language=objc)
 
 ### macos: scroll
 
@@ -109,12 +119,17 @@ Perform scroll gesture on an element or by relative/absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | if `x` or `y` are unset | Unique identifier of the element to be scrolled. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-x | number | if `y` is set or `element` is unset | scroll X coordinate | 100
-y | number | if `y` is set or `element` is unset | scroll Y coordinate | 100
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | Unique identifier of the element to be scrolled. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+x | number | if `y` is set or `elementId` is unset | scroll X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | scroll Y coordinate | 100
 deltaX | number | yes | Horizontal delta as float number. Could be negative | 100
 deltaY | number | yes | vertical delta as float number. Could be negative | 100
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while scroll is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [scrollByDeltaX:deltaY: (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1500758-scrollbydeltax?language=objc)
+- [scrollByDeltaX:deltaY: (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate?language=objc)
 
 ### macos: rightClick
 
@@ -124,10 +139,17 @@ Perform right click gesture on an element or by relative/absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | if `x` or `y` are unset | Unique identifier of the element to perform the right click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-x | number | if `y` is set or `element` is unset | right click X coordinate | 100
-y | number | if `y` is set or `element` is unset | right click Y coordinate | 100
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | Unique identifier of the element to perform the right click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+x | number | if `y` is set or `elementId` is unset | right click X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | right click Y coordinate | 100
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while right click is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [rightClick (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1500469-rightclick?language=objc)
+- [rightClick (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/1500503-rightclick?language=objc)
+
+### macos: rightClick
 
 ### macos: hover
 
@@ -137,10 +159,15 @@ Perform hover gesture on an element or by relative/absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | if `x` or `y` are unset | Unique identifier of the element to perform the hover on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-x | number | if `y` is set or `element` is unset | long click X coordinate | 100
-y | number | if `y` is set or `element` is unset | long click Y coordinate | 100
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | Unique identifier of the element to perform the hover on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+x | number | if `y` is set or `elementId` is unset | long click X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | long click Y coordinate | 100
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while hover is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [hover (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1500437-hover?language=objc)
+- [hover (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/1501021-hover?language=objc)
 
 ### macos: doubleClick
 
@@ -150,10 +177,15 @@ Perform double click gesture on an element or by relative/absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | if `x` or `y` are unset | Unique identifier of the element to perform the double click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-x | number | if `y` is set or `element` is unset | double click X coordinate | 100
-y | number | if `y` is set or `element` is unset | double click Y coordinate | 100
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | Unique identifier of the element to perform the double click on. Either this property or/and x and y must be set. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+x | number | if `y` is set or `elementId` is unset | double click X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | double click Y coordinate | 100
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while click is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [doubleClick (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1500571-doubleclick?language=objc)
+- [doubleClick (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/1500302-doubleclick?language=objc)
 
 ### macos: clickAndDrag
 
@@ -163,14 +195,19 @@ Perform long click and drag gesture on an element or by absolute coordinates
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-sourceElement | string | if `startX`, `startY`, `endX` and `endY` are unset or if `destinationElement` is set | Uuid of the element to start the drag from. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-destinationElement | string | if `startX`, `startY`, `endX` and `endY` are unset or if `sourceElement` is set | Uuid of the element to end the drag on. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0745
-startX | number | if `sourceElement` and `destinationElement` are unset | starting X coordinate | 100
-startY | number | if `sourceElement` and `destinationElement` are unset | starting Y coordinate | 110
-endX | number | if `sourceElement` and `destinationElement` are unset | end X coordinate | 200
-endY | number | if `sourceElement` and `destinationElement` are unset | end Y coordinate | 220
+sourceElementId ("sourceElement" prior to Appium v 1.22) | string | if `startX`, `startY`, `endX` and `endY` are unset or if `destinationElementId` is set | Uuid of the element to start the drag from. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+destinationElementId ("destinationElement" prior to Appium v 1.22) | string | if `startX`, `startY`, `endX` and `endY` are unset or if `sourceElementId` is set | Uuid of the element to end the drag on. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0745
+startX | number | if `sourceElementId` and `destinationElementId` are unset | starting X coordinate | 100
+startY | number | if `sourceElementId` and `destinationElementId` are unset | starting Y coordinate | 110
+endX | number | if `sourceElementId` and `destinationElementId` are unset | end X coordinate | 200
+endY | number | if `sourceElementId` and `destinationElementId` are unset | end Y coordinate | 220
 duration | number | yes | The number of float seconds to hold the mouse button | 2.5
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while drag is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [clickForDuration:thenDragToCoordinate: (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1500989-clickforduration?language=objc)
+- [clickForDuration:thenDragToCoordinate: (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/1500369-clickforduration?language=objc)
 
 ### macos: clickDragAndDrag
 
@@ -180,15 +217,44 @@ Perform long click, drag and hold gesture on an element or by absolute coordinat
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-sourceElement | string | if `startX`, `startY`, `endX` and `endY` are unset or if `destinationElement` is set | Uuid of the element to start the drag from. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
-destinationElement | string | if `startX`, `startY`, `endX` and `endY` are unset or if `sourceElement` is set | Uuid of the element to end the drag on. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0745
-startX | number | if `sourceElement` and `destinationElement` are unset | starting X coordinate | 100
-startY | number | if `sourceElement` and `destinationElement` are unset | starting Y coordinate | 110
-endX | number | if `sourceElement` and `destinationElement` are unset | end X coordinate | 200
-endY | number | if `sourceElement` and `destinationElement` are unset | end Y coordinate | 220
+sourceElementId ("sourceElement" prior to Appium v 1.22) | string | if `startX`, `startY`, `endX` and `endY` are unset or if `destinationElementId` is set | Uuid of the element to start the drag from. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+destinationElementId ("destinationElement" prior to Appium v 1.22) | string | if `startX`, `startY`, `endX` and `endY` are unset or if `sourceElementId` is set | Uuid of the element to end the drag on. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0745
+startX | number | if `sourceElementId` and `destinationElementId` are unset | starting X coordinate | 100
+startY | number | if `sourceElementId` and `destinationElementId` are unset | starting Y coordinate | 110
+endX | number | if `sourceElementId` and `destinationElementId` are unset | end X coordinate | 200
+endY | number | if `sourceElementId` and `destinationElementId` are unset | end Y coordinate | 220
 duration | number | yes | The number of float seconds to hold the mouse button | 2.5
 velocity | number | no | Dragging velocity in pixels per second. If not provided then the default velocity is used. See official documentation on [XCUIGestureVelocity structure](https://developer.apple.com/documentation/xctest/xcuigesturevelocity) for more details | 2500
 keyModifierFlags | number | no | if set then the given key modifiers will be applied while drag is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [clickForDuration:thenDragToElement:withVelocity:thenHoldForDuration: (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/3553192-clickforduration?language=objc)
+- [clickForDuration:thenDragToElement:withVelocity:thenHoldForDuration: (XCUICoordinate)](hhttps://developer.apple.com/documentation/xctest/xcuicoordinate/3553191-clickforduration?language=objc)
+
+### mobile: swipe
+
+This extension performs a swipe gesture on the particular screen element or by given coordinates.
+The API is only available on macOS since Xcode SDK 13.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+elementId ("element" prior to Appium v 1.22) | string | if `x` or `y` are unset | The internal element identifier (as hexadecimal hash string) to swipe on. If both are set then x and y are considered as relative element coordinates. If only x and y are set then these are parsed as absolute coordinates. | fe50b60b-916d-420b-8728-ee2072ec53eb
+x | number | if `y` is set or `elementId` is unset | long click X coordinate | 100
+y | number | if `y` is set or `elementId` is unset | long click Y coordinate | 100
+direction | Either 'up', 'down', 'left' or 'right' | yes | The direction in which to swipe | up
+velocity | number | no | The value is measured in pixels per second and same values could behave differently on different devices depending on their display density. Higher values make swipe gesture faster (which usually scrolls larger areas if we apply it to a list) and lower values slow it down. Only values greater than zero have effect. | 250
+keyModifierFlags | number | no | if set then the given key modifiers will be applied while swipe is performed. See the official documentation on [XCUIKeyModifierFlags enumeration](https://developer.apple.com/documentation/xctest/xcuikeymodifierflags) for more details | `1 << 1 | 1 << 2`
+
+#### References
+
+- [swipeDown (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/1618664-swipedown?language=objc)
+- [swipeDown (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/3752780-swipedown?language=objc)
+- [swipeDownWithVelocity: (XCUIElement)](https://developer.apple.com/documentation/xctest/xcuielement/3551694-swipedownwithvelocity?language=objc)
+- [swipeDownWithVelocity: (XCUICoordinate)](https://developer.apple.com/documentation/xctest/xcuicoordinate/3752781-swipedownwithvelocity?language=objc)
+- ...
 
 ### macos: keys
 
@@ -198,8 +264,12 @@ Send keys to the given element or to the application under test
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | no | Unique identifier of the element to send the keys to. If unset then keys are sent to the current application under test. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
+elementId ("element" prior to Appium v 1.22) | string | no | Unique identifier of the element to send the keys to. If unset then keys are sent to the current application under test. | 21045BC8-013C-43BD-9B1E-4C6DC7AB0744
 keys | array | yes | Array of keys to type. Each item could either be a string, that represents a key itself (see the official documentation on XCUIElement's [typeKey:modifierFlags: method](https://developer.apple.com/documentation/xctest/xcuielement/1500604-typekey?language=objc) and on [XCUIKeyboardKey constants](https://developer.apple.com/documentation/xctest/xcuikeyboardkey?language=objc)) or a dictionary with `key` and `modifierFlags` entries, if the key should also be entered with modifiers. | ['h', 'i'] or [{key: 'h', modifierFlags: 1 << 1}, {key: 'i', modifierFlags: 1 << 2}] or ['XCUIKeyboardKeyEscape'] |
+
+#### References
+
+- [typeKey:modifierFlags:](https://developer.apple.com/documentation/xctest/xcuielement/1500604-typekey?language=objc)
 
 ### macos: source
 

--- a/WebDriverAgentMac/IntegrationTests/AMVariousElementTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMVariousElementTests.m
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "AMIntegrationTestCase.h"
+#import "XCUIElement+AMSwipe.h"
+#import "XCUICoordinate+AMSwipe.h"
+
+@interface AMVariousElementTests : AMIntegrationTestCase
+@end
+
+@implementation AMVariousElementTests
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+  });
+}
+
+- (void)testSwipeElement
+{
+  XCUIElement *slider = self.testedApplication.sliders.firstMatch;
+  NSError *error;
+  XCTAssertTrue([slider am_swipeWithDirection:@"right" velocity:nil error:&error]);
+  XCTAssertNil(error);
+}
+
+- (void)testSwipeCoordinates
+{
+  XCUIElement *slider = self.testedApplication.sliders.firstMatch;
+  NSError *error;
+  XCUICoordinate *destPoint = [slider coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
+  XCTAssertTrue([destPoint am_swipeWithDirection:@"right"
+                                        velocity:@(200)
+                                           error:&error]);
+  XCTAssertNil(error);
+}
+
+@end

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUICoordinate+AMSwipe.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUICoordinate+AMSwipe.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUICoordinate (AMSwipe)
+
+/**
+ * Performs swipe gesture on the coordinate
+ *
+ * @param direction Swipe direction. The following values are supported: up, down, left and right
+ * @param velocity Swipe speed in pixels per second. This parameter is only supported since Xcode 11.4
+ * nil value means that the default velocity is going to be used.
+ * @param error The actual error description if the method fails to perform swipe
+ * @returns YES if the swipe action was successful
+ */
+- (BOOL)am_swipeWithDirection:(NSString *)direction
+                     velocity:(nullable NSNumber *)velocity
+                        error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUICoordinate+AMSwipe.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUICoordinate+AMSwipe.m
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "XCUICoordinate+AMSwipe.h"
+
+#import "AMSwipeHelpers.h"
+
+@implementation XCUICoordinate (AMSwipe)
+
+
+- (BOOL)am_swipeWithDirection:(NSString *)direction
+                     velocity:(nullable NSNumber *)velocity
+                        error:(NSError **)error
+{
+  return AMPerformSwipe(self, direction, velocity, error);
+}
+
+@end

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMSwipe.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMSwipe.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIElement (AMSwipe)
+
+/**
+ * Performs swipe gesture on the element
+ *
+ * @param direction Swipe direction. The following values are supported: up, down, left and right
+ * @param velocity Swipe speed in pixels per second. This parameter is only supported since Xcode 11.4
+ * nil value means that the default velocity is going to be used.
+ * @param error The actual error description if the method fails to perform swipe
+ * @returns YES if the swipe action was successful
+ */
+- (BOOL)am_swipeWithDirection:(NSString *)direction
+                     velocity:(nullable NSNumber *)velocity
+                        error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMSwipe.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMSwipe.m
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "XCUIElement+AMSwipe.h"
+
+#import "AMSwipeHelpers.h"
+
+@implementation XCUIElement (AMSwipe)
+
+- (BOOL)am_swipeWithDirection:(NSString *)direction
+                     velocity:(nullable NSNumber *)velocity
+                        error:(NSError **)error
+{
+  return AMPerformSwipe(self, direction, velocity, error);
+}
+
+@end

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSwipeHelpers.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSwipeHelpers.h
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Performs swipe gesture on the given XCTest UI object (either XCUICoordinate or XCUIElement)
+ *
+ * @param dest UI object instance
+ * @param direction Swipe direction. The following values are supported: up, down, left and right
+ * @param velocity Swipe speed in pixels per second. This parameter is only supported since Xcode 11.4
+ * nil value means that the default velocity is going to be used.
+ * @param error The actual error description if the method fails to perform swipe
+ * @returns YES if the swipe action was successful
+ */
+BOOL AMPerformSwipe(NSObject *dest, NSString *direction, NSNumber *_Nullable velocity, NSError **error);
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSwipeHelpers.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSwipeHelpers.m
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#import "AMSwipeHelpers.h"
+
+#import "FBLogger.h"
+#import "FBErrorBuilder.h"
+
+
+BOOL AMPerformSwipe(NSObject *dest, NSString *direction, NSNumber *velocity, NSError **error)
+{
+  double velocityValue = .0;
+  if (nil != velocity) {
+    if ([dest respondsToSelector:NSSelectorFromString(@"swipeUpWithVelocity:")]) {
+      velocityValue = [velocity doubleValue];
+    } else {
+      [FBLogger log:@"Custom velocity values are not supported by the current Xcode SDK. The default velocity will be used instead"];
+    }
+  }
+
+  if (velocityValue > 0) {
+    NSString *selectorName = [NSString stringWithFormat:@"swipe%@WithVelocity:", direction.lowercaseString.capitalizedString];
+    SEL selector = NSSelectorFromString(selectorName);
+    NSMethodSignature *signature = [dest methodSignatureForSelector:selector];
+    if (nil == signature) {
+      return [[[FBErrorBuilder builder]
+               withDescriptionFormat:@"%@ method of %@ is not supported by the current Xcode SDK", selectorName, [dest className]]
+              buildError:error];;
+    }
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:selector];
+    [invocation setArgument:&velocityValue atIndex:2];
+    [invocation invokeWithTarget:dest];
+  } else {
+    NSString *selectorName = [NSString stringWithFormat:@"swipe%@", direction.lowercaseString.capitalizedString];
+    SEL selector = NSSelectorFromString(selectorName);
+    NSMethodSignature *signature = [dest methodSignatureForSelector:selector];
+    if (nil == signature) {
+      return [[[FBErrorBuilder builder]
+               withDescriptionFormat:@"%@ method of %@ is not supported by the current Xcode SDK", selectorName, [dest className]]
+              buildError:error];
+    }
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:selector];
+    [invocation invokeWithTarget:dest];
+  }
+  return YES;
+}
+

--- a/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/project.pbxproj
+++ b/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/project.pbxproj
@@ -178,6 +178,13 @@
 		71B00E9B2566D7B00010DA73 /* WebDriverAgentLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7199B3AB2565B122000B5C51 /* WebDriverAgentLib.framework */; };
 		71B00EA02566D9570010DA73 /* AMFindElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B00E9F2566D9570010DA73 /* AMFindElementTests.m */; };
 		71B00EA62566DBAF0010DA73 /* AMSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B00EA52566DBAF0010DA73 /* AMSourceTests.m */; };
+		71B8B67926724B9F009CE50C /* XCUIElement+AMSwipe.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B8B67726724B9F009CE50C /* XCUIElement+AMSwipe.h */; };
+		71B8B67A26724B9F009CE50C /* XCUIElement+AMSwipe.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B8B67826724B9F009CE50C /* XCUIElement+AMSwipe.m */; };
+		71B8B67D26725A01009CE50C /* XCUICoordinate+AMSwipe.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B8B67B26725A01009CE50C /* XCUICoordinate+AMSwipe.h */; };
+		71B8B67E26725A01009CE50C /* XCUICoordinate+AMSwipe.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B8B67C26725A01009CE50C /* XCUICoordinate+AMSwipe.m */; };
+		71B8B68126726369009CE50C /* AMSwipeHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B8B67F26726369009CE50C /* AMSwipeHelpers.h */; };
+		71B8B68226726369009CE50C /* AMSwipeHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B8B68026726369009CE50C /* AMSwipeHelpers.m */; };
+		71B8B684267265D7009CE50C /* AMVariousElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B8B683267265D7009CE50C /* AMVariousElementTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -400,6 +407,13 @@
 		71B00E9C2566D7F10010DA73 /* AMIntegrationTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMIntegrationTestCase.h; sourceTree = "<group>"; };
 		71B00E9F2566D9570010DA73 /* AMFindElementTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMFindElementTests.m; sourceTree = "<group>"; };
 		71B00EA52566DBAF0010DA73 /* AMSourceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMSourceTests.m; sourceTree = "<group>"; };
+		71B8B67726724B9F009CE50C /* XCUIElement+AMSwipe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+AMSwipe.h"; sourceTree = "<group>"; };
+		71B8B67826724B9F009CE50C /* XCUIElement+AMSwipe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+AMSwipe.m"; sourceTree = "<group>"; };
+		71B8B67B26725A01009CE50C /* XCUICoordinate+AMSwipe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUICoordinate+AMSwipe.h"; sourceTree = "<group>"; };
+		71B8B67C26725A01009CE50C /* XCUICoordinate+AMSwipe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUICoordinate+AMSwipe.m"; sourceTree = "<group>"; };
+		71B8B67F26726369009CE50C /* AMSwipeHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMSwipeHelpers.h; sourceTree = "<group>"; };
+		71B8B68026726369009CE50C /* AMSwipeHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMSwipeHelpers.m; sourceTree = "<group>"; };
+		71B8B683267265D7009CE50C /* AMVariousElementTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMVariousElementTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -577,6 +591,8 @@
 				719E6A6D25822DB800777988 /* XCUIApplication+AMUIInterruptions.m */,
 				7180C1DE257A9410008FA870 /* XCUIApplication+FBW3CActions.h */,
 				7180C1DF257A9410008FA870 /* XCUIApplication+FBW3CActions.m */,
+				71B8B67B26725A01009CE50C /* XCUICoordinate+AMSwipe.h */,
+				71B8B67C26725A01009CE50C /* XCUICoordinate+AMSwipe.m */,
 				718D2BD725670A76005F533B /* XCUIElement+AMAttributes.h */,
 				718D2BD825670A76005F533B /* XCUIElement+AMAttributes.m */,
 				718D2BE7256713FD005F533B /* XCUIElement+AMCoordinates.h */,
@@ -585,6 +601,8 @@
 				718D2C0C2567AA03005F533B /* XCUIElement+AMEditable.m */,
 				7180C214257AA707008FA870 /* XCUIElement+AMHitPoint.h */,
 				7180C215257AA707008FA870 /* XCUIElement+AMHitPoint.m */,
+				71B8B67726724B9F009CE50C /* XCUIElement+AMSwipe.h */,
+				71B8B67826724B9F009CE50C /* XCUIElement+AMSwipe.m */,
 				713A9D2B25669E4F00118D07 /* XCUIElement+FBClassChain.h */,
 				713A9D2A25669E4E00118D07 /* XCUIElement+FBClassChain.m */,
 				713A9D2625669A6B00118D07 /* XCUIElement+FBFind.h */,
@@ -665,6 +683,8 @@
 				718D2BF225678B4E005F533B /* AMSnapshotUtils.m */,
 				7151AD7E2564F56E008B8B2A /* AMSettings.h */,
 				7151ADAC2564F570008B8B2A /* AMSettings.m */,
+				71B8B67F26726369009CE50C /* AMSwipeHelpers.h */,
+				71B8B68026726369009CE50C /* AMSwipeHelpers.m */,
 				7180C1C8257A9336008FA870 /* FBBaseActionsSynthesizer.h */,
 				7180C1C9257A9336008FA870 /* FBBaseActionsSynthesizer.m */,
 				7151AD7B2564F56E008B8B2A /* FBClassChainQueryParser.h */,
@@ -760,6 +780,7 @@
 				71B00E8D2566D4BA0010DA73 /* AMIntegrationTestCase.m */,
 				718D2C282567E6D0005F533B /* AMSessionTests.m */,
 				71B00EA52566DBAF0010DA73 /* AMSourceTests.m */,
+				71B8B683267265D7009CE50C /* AMVariousElementTests.m */,
 				7180C21C257AC27F008FA870 /* AMW3CActionsTests.m */,
 				718D2C132567B465005F533B /* FBTestMacros.h */,
 				71B00E8F2566D4BA0010DA73 /* Info.plist */,
@@ -807,11 +828,13 @@
 				7109C01C2565B58C006BFD13 /* FBSession-Private.h in Headers */,
 				7109BFED2565B546006BFD13 /* FBElementUtils.h in Headers */,
 				7109C05D2565B5F6006BFD13 /* HTTPMessage.h in Headers */,
+				71B8B67D26725A01009CE50C /* XCUICoordinate+AMSwipe.h in Headers */,
 				7168D5AE258B849B00EEFA12 /* LRUCache.h in Headers */,
 				7109C03D2565B5BF006BFD13 /* NSPredicate+FBFormat.h in Headers */,
 				7180C1DA257A9369008FA870 /* AMActionCommands.h in Headers */,
 				713A9D2D25669E4F00118D07 /* XCUIElement+FBClassChain.h in Headers */,
 				7109C0422565B5C7006BFD13 /* XCUIApplication+AMHelpers.h in Headers */,
+				71B8B67926724B9F009CE50C /* XCUIElement+AMSwipe.h in Headers */,
 				7109BFBD2565B4FC006BFD13 /* FBElementTypeTransformer.h in Headers */,
 				7180C1D2257A9348008FA870 /* FBW3CActionsSynthesizer.h in Headers */,
 				7109BFC72565B50B006BFD13 /* FBLogger.h in Headers */,
@@ -844,6 +867,7 @@
 				7109C05B2565B5F3006BFD13 /* HTTPLogging.h in Headers */,
 				7109C0472565B5DB006BFD13 /* DDNumber.h in Headers */,
 				7109C0772565B616006BFD13 /* RoutingConnection.h in Headers */,
+				71B8B68126726369009CE50C /* AMSwipeHelpers.h in Headers */,
 				7180C1D3257A9348008FA870 /* FBW3CActionsHelpers.h in Headers */,
 				7109C0172565B581006BFD13 /* FBRouteRequest.h in Headers */,
 				7180C216257AA707008FA870 /* XCUIElement+AMHitPoint.h in Headers */,
@@ -1091,6 +1115,7 @@
 				7109C0592565B5F1006BFD13 /* HTTPConnection.m in Sources */,
 				713A9D12256683E900118D07 /* XCUIElementQuery+AMHelpers.m in Sources */,
 				7109C01A2565B58A006BFD13 /* FBRouteRequest.m in Sources */,
+				71B8B67A26724B9F009CE50C /* XCUIElement+AMSwipe.m in Sources */,
 				719E6A6F25822DB800777988 /* XCUIApplication+AMUIInterruptions.m in Sources */,
 				7109C07D2565B61D006BFD13 /* RoutingHTTPServer.m in Sources */,
 				7109C06D2565B60A006BFD13 /* Route.m in Sources */,
@@ -1098,11 +1123,13 @@
 				7109C0022565B561006BFD13 /* FBResponseJSONPayload.m in Sources */,
 				7109C00C2565B56E006BFD13 /* FBRuntimeUtils.m in Sources */,
 				7109C0072565B568006BFD13 /* FBResponsePayload.m in Sources */,
+				71B8B68226726369009CE50C /* AMSwipeHelpers.m in Sources */,
 				713A9D2C25669E4F00118D07 /* XCUIElement+FBClassChain.m in Sources */,
 				7109BFE62565B53D006BFD13 /* FBCommandStatus.m in Sources */,
 				7180C217257AA707008FA870 /* XCUIElement+AMHitPoint.m in Sources */,
 				7109C0272565B59D006BFD13 /* FBWebServer.m in Sources */,
 				7109C0362565B5B4006BFD13 /* FBUnknownCommands.m in Sources */,
+				71B8B67E26725A01009CE50C /* XCUICoordinate+AMSwipe.m in Sources */,
 				718D2C332567FED3005F533B /* AMSessionCapabilities.m in Sources */,
 				7109C02C2565B5A7006BFD13 /* FBSessionCommands.m in Sources */,
 				718EE0BB256B0A0300B46325 /* NSString+FBXMLSafeString.m in Sources */,
@@ -1129,6 +1156,7 @@
 				71B00EA02566D9570010DA73 /* AMFindElementTests.m in Sources */,
 				718D2C082567A028005F533B /* AMElementAttributesTests.m in Sources */,
 				7180C21D257AC27F008FA870 /* AMW3CActionsTests.m in Sources */,
+				71B8B684267265D7009CE50C /* AMVariousElementTests.m in Sources */,
 				718D2C292567E6D0005F533B /* AMSessionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -8,6 +8,7 @@ const EXTENSION_COMMANDS_MAPPING = {
   setValue: 'macosSetValue',
   click: 'macosClick',
   scroll: 'macosScroll',
+  swipe: 'macosSwipe',
   rightClick: 'macosRightClick',
   hover: 'macosHover',
   doubleClick: 'macosDoubleClick',

--- a/lib/commands/gestures.js
+++ b/lib/commands/gestures.js
@@ -1,10 +1,24 @@
 import { util } from 'appium-support';
+import { errors } from 'appium-base-driver';
 
 const commands = {};
 
+function requireUuid (options = {}, keyNames = ['elementId', 'element']) {
+  for (const name of keyNames) {
+    if (options[name]) {
+      const result = util.unwrapElement(options[name]);
+      if (result) {
+        return result;
+      }
+    }
+  }
+  throw new errors.InvalidArgumentError(`${keyNames[0]} field is mandatory`);
+}
+
+
 /**
  * @typedef {Object} SetValueOptions
- * @property {!string} element uuid of the element to set value for
+ * @property {!string} elementId uuid of the element to set value for
  * @property {*} value value to set. Could also be an array
  * @property {string} text text to set. If both value and text are set
  * then `value` is preferred
@@ -20,7 +34,7 @@ const commands = {};
  * @param {SetValueOptions} opts
  */
 commands.macosSetValue = async function macosSetValue (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { value, text, keyModifierFlags } = opts;
   return await this.wda.proxy.command(`/element/${uuid}/value`, 'POST', {
     value, text,
@@ -30,7 +44,7 @@ commands.macosSetValue = async function macosSetValue (opts = {}) {
 
 /**
  * @typedef {Object} ClickOptions
- * @property {?string} element uuid of the element to click. Either this property
+ * @property {?string} elementId uuid of the element to click. Either this property
  * or/and x and y must be set. If both are set then x and y are considered as relative
  * element coordinates. If only x and y are set then these are parsed as
  * absolute coordinates.
@@ -48,7 +62,7 @@ commands.macosSetValue = async function macosSetValue (opts = {}) {
  * @param {ClickOptions} opts
  */
 commands.macosClick = async function macosClick (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/element/${uuid}/click` : '/wda/click';
   return await this.wda.proxy.command(url, 'POST', {
@@ -59,7 +73,7 @@ commands.macosClick = async function macosClick (opts = {}) {
 
 /**
  * @typedef {Object} ClickAndHoldOptions
- * @property {?string} element uuid of the element to be long clicked. Either this property
+ * @property {?string} elementId uuid of the element to be long clicked. Either this property
  * or/and x and y must be set. If both are set then x and y are considered as relative
  * element coordinates. If only x and y are set then these are parsed as
  * absolute coordinates.
@@ -78,7 +92,7 @@ commands.macosClick = async function macosClick (opts = {}) {
  * @param {ClickAndHoldOptions} opts
  */
 commands.macosClickAndHold = async function macosClickAndHold (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { x, y, duration, keyModifierFlags } = opts;
   const url = uuid ? `/element/${uuid}/clickAndHold` : '/wda/clickAndHold';
   return await this.wda.proxy.command(url, 'POST', {
@@ -90,7 +104,7 @@ commands.macosClickAndHold = async function macosClickAndHold (opts = {}) {
 
 /**
  * @typedef {Object} ScrollOptions
- * @property {?string} element uuid of the element to be scrolled. Either this property
+ * @property {?string} elementId uuid of the element to be scrolled. Either this property
  * or/and x and y must be set. If both are set then x and y are considered as relative
  * element coordinates. If only x and y are set then these are parsed as
  * absolute coordinates.
@@ -110,7 +124,7 @@ commands.macosClickAndHold = async function macosClickAndHold (opts = {}) {
  * @param {ScrollOptions} opts
  */
 commands.macosScroll = async function macosScroll (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const {
     x, y,
     deltaX, deltaY,
@@ -125,8 +139,49 @@ commands.macosScroll = async function macosScroll (opts = {}) {
 };
 
 /**
+ * @typedef {Object} SwipeOptions
+ * @property {?string} elementId uuid of the element to be swiped. Either this property
+ * or/and x and y must be set. If both are set then x and y are considered as relative
+ * element coordinates. If only x and y are set then these are parsed as
+ * absolute coordinates.
+ * @property {?number} x swipe X coordinate
+ * @property {?number} y swipe Y coordinate
+ * @property {!string} direction either 'up', 'down', 'left' or 'right'
+ * @property {?number} velocity The value is measured in pixels per second and same
+ * values could behave differently on different devices depending on their display
+ * density. Higher values make swipe gesture faster (which usually scrolls larger
+ * areas if we apply it to a list) and lower values slow it down.
+ * Only values greater than zero have effect.
+ * @property {?number} keyModifierFlags if set then the given key modifiers will be
+ * applied while scroll is performed. See
+ * https://developer.apple.com/documentation/xctest/xcuikeymodifierflags
+ * for more details
+ */
+
+/**
+ * Perform swipe gesture on an element
+ *
+ * @param {SwipeOptions} opts
+ */
+commands.macosSwipe = async function macosSwipe (opts = {}) {
+  const uuid = requireUuid(opts);
+  const {
+    x, y,
+    direction,
+    velocity,
+    keyModifierFlags,
+  } = opts;
+  return await this.wda.proxy.command(`/wda/element/${uuid}/swipe`, 'POST', {
+    x, y,
+    direction,
+    velocity,
+    keyModifierFlags,
+  });
+};
+
+/**
  * @typedef {Object} RightClickOptions
- * @property {?string} element uuid of the element to click. Either this property
+ * @property {?string} elementId uuid of the element to click. Either this property
  * or/and x and y must be set. If both are set then x and y are considered as relative
  * element coordinates. If only x and y are set then these are parsed as
  * absolute coordinates.
@@ -144,7 +199,7 @@ commands.macosScroll = async function macosScroll (opts = {}) {
  * @param {RightClickOptions} opts
  */
 commands.macosRightClick = async function macosRightClick (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/wda/element/${uuid}/rightClick` : '/wda/rightClick';
   return await this.wda.proxy.command(url, 'POST', {
@@ -155,7 +210,7 @@ commands.macosRightClick = async function macosRightClick (opts = {}) {
 
 /**
  * @typedef {Object} HoverOptions
- * @property {?string} element uuid of the element to hover. Either this property
+ * @property {?string} elementId uuid of the element to hover. Either this property
  * or/and x and y must be set. If both are set then x and y are considered as relative
  * element coordinates. If only x and y are set then these are parsed as
  * absolute coordinates.
@@ -173,7 +228,7 @@ commands.macosRightClick = async function macosRightClick (opts = {}) {
  * @param {HoverOptions} opts
  */
 commands.macosHover = async function macosHover (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/wda/element/${uuid}/hover` : '/wda/hover';
   return await this.wda.proxy.command(url, 'POST', {
@@ -184,7 +239,7 @@ commands.macosHover = async function macosHover (opts = {}) {
 
 /**
  * @typedef {Object} DoubleClickOptions
- * @property {?string} element uuid of the element to double click. Either this property
+ * @property {?string} elementId uuid of the element to double click. Either this property
  * or/and x and y must be set. If both are set then x and y are considered as relative
  * element coordinates. If only x and y are set then these are parsed as
  * absolute coordinates.
@@ -202,7 +257,7 @@ commands.macosHover = async function macosHover (opts = {}) {
  * @param {DoubleClickOptions} opts
  */
 commands.macosDoubleClick = async function macosDoubleClick (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/wda/element/${uuid}/doubleClick` : '/wda/doubleClick';
   return await this.wda.proxy.command(url, 'POST', {
@@ -213,10 +268,10 @@ commands.macosDoubleClick = async function macosDoubleClick (opts = {}) {
 
 /**
  * @typedef {Object} ClickAndDragOptions
- * @property {?string} sourceElement uuid of the element to start the drag from. Either this property
+ * @property {?string} sourceElementId uuid of the element to start the drag from. Either this property
  * and `destinationElement` must be provided or `startX`, `startY`, `endX`, `endY` coordinates
  * must be set.
- * @property {?string} destinationElement uuid of the element to end the drag on. Either this property
+ * @property {?string} destinationElementId uuid of the element to end the drag on. Either this property
  * and `sourceElement` must be provided or `startX`, `startY`, `endX`, `endY` coordinates
  * must be set.
  * @property {?number} startX starting X coordinate
@@ -236,8 +291,8 @@ commands.macosDoubleClick = async function macosDoubleClick (opts = {}) {
  * @param {ClickAndDragOptions} opts
  */
 commands.macosClickAndDrag = async function macosClickAndDrag (opts = {}) {
-  const sourceUuid = util.unwrapElement(opts.sourceElement);
-  const destUuid = util.unwrapElement(opts.destinationElement);
+  const sourceUuid = requireUuid(opts, ['sourceElementId', 'sourceElement']);
+  const destUuid = requireUuid(opts, ['destinationElementId', 'destinationElement']);
   const {
     startX, startY,
     endX, endY,
@@ -259,10 +314,10 @@ commands.macosClickAndDrag = async function macosClickAndDrag (opts = {}) {
 
 /**
  * @typedef {Object} ClickDragAndHoldOptions
- * @property {?string} sourceElement uuid of the element to start the drag from. Either this property
+ * @property {?string} sourceElementId uuid of the element to start the drag from. Either this property
  * and `destinationElement` must be provided or `startX`, `startY`, `endX`, `endY` coordinates
  * must be set.
- * @property {?string} destinationElement uuid of the element to end the drag on. Either this property
+ * @property {?string} destinationElementId uuid of the element to end the drag on. Either this property
  * and `sourceElement` must be provided or `startX`, `startY`, `endX`, `endY` coordinates
  * must be set.
  * @property {?number} startX starting X coordinate
@@ -286,8 +341,8 @@ commands.macosClickAndDrag = async function macosClickAndDrag (opts = {}) {
  * @param {ClickDragAndHoldOptions} opts
  */
 commands.macosClickDragAndHold = async function macosClickDragAndHold (opts = {}) {
-  const sourceUuid = util.unwrapElement(opts.sourceElement);
-  const destUuid = util.unwrapElement(opts.destinationElement);
+  const sourceUuid = requireUuid(opts, ['sourceElementId', 'sourceElement']);
+  const destUuid = requireUuid(opts, ['destinationElementId', 'destinationElement']);
   const {
     startX, startY,
     endX, endY,
@@ -321,7 +376,7 @@ commands.macosClickDragAndHold = async function macosClickDragAndHold (opts = {}
 
 /**
  * @typedef {Object} KeysOptions
- * @property {?string} element uuid of the element to send keys to.
+ * @property {?string} elementId uuid of the element to send keys to.
  * If the element is not provided then the keys will be sent to the current application.
  * @property {!Array<KeyOptions|string>} keys Array of keys to type.
  * Each item could either be a string, that represents a key itself (see
@@ -336,7 +391,7 @@ commands.macosClickDragAndHold = async function macosClickDragAndHold (opts = {}
  * @param {KeysOptions} opts
  */
 commands.macosKeys = async function macosKeys (opts = {}) {
-  const uuid = util.unwrapElement(opts.element);
+  const uuid = requireUuid(opts);
   const { keys } = opts;
   const url = uuid ? `/wda/element/${uuid}/keys` : '/wda/keys';
   return await this.wda.proxy.command(url, 'POST', { keys });

--- a/lib/commands/gestures.js
+++ b/lib/commands/gestures.js
@@ -3,7 +3,7 @@ import { errors } from 'appium-base-driver';
 
 const commands = {};
 
-function requireUuid (options = {}, keyNames = ['elementId', 'element']) {
+function extractUuid (options = {}, keyNames = ['elementId', 'element']) {
   for (const name of keyNames) {
     if (options[name]) {
       const result = util.unwrapElement(options[name]);
@@ -12,7 +12,15 @@ function requireUuid (options = {}, keyNames = ['elementId', 'element']) {
       }
     }
   }
-  throw new errors.InvalidArgumentError(`${keyNames[0]} field is mandatory`);
+  return null;
+}
+
+function requireUuid (options = {}, keyNames = ['elementId', 'element']) {
+  const result = extractUuid(options, keyNames);
+  if (!result) {
+    throw new errors.InvalidArgumentError(`${keyNames[0]} field is mandatory`);
+  }
+  return result;
 }
 
 
@@ -62,7 +70,7 @@ commands.macosSetValue = async function macosSetValue (opts = {}) {
  * @param {ClickOptions} opts
  */
 commands.macosClick = async function macosClick (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/element/${uuid}/click` : '/wda/click';
   return await this.wda.proxy.command(url, 'POST', {
@@ -92,7 +100,7 @@ commands.macosClick = async function macosClick (opts = {}) {
  * @param {ClickAndHoldOptions} opts
  */
 commands.macosClickAndHold = async function macosClickAndHold (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const { x, y, duration, keyModifierFlags } = opts;
   const url = uuid ? `/element/${uuid}/clickAndHold` : '/wda/clickAndHold';
   return await this.wda.proxy.command(url, 'POST', {
@@ -124,7 +132,7 @@ commands.macosClickAndHold = async function macosClickAndHold (opts = {}) {
  * @param {ScrollOptions} opts
  */
 commands.macosScroll = async function macosScroll (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const {
     x, y,
     deltaX, deltaY,
@@ -164,14 +172,15 @@ commands.macosScroll = async function macosScroll (opts = {}) {
  * @param {SwipeOptions} opts
  */
 commands.macosSwipe = async function macosSwipe (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const {
     x, y,
     direction,
     velocity,
     keyModifierFlags,
   } = opts;
-  return await this.wda.proxy.command(`/wda/element/${uuid}/swipe`, 'POST', {
+  const url = uuid ? `/wda/element/${uuid}/swipe` : `/wda/swipe`;
+  return await this.wda.proxy.command(url, 'POST', {
     x, y,
     direction,
     velocity,
@@ -199,7 +208,7 @@ commands.macosSwipe = async function macosSwipe (opts = {}) {
  * @param {RightClickOptions} opts
  */
 commands.macosRightClick = async function macosRightClick (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/wda/element/${uuid}/rightClick` : '/wda/rightClick';
   return await this.wda.proxy.command(url, 'POST', {
@@ -228,7 +237,7 @@ commands.macosRightClick = async function macosRightClick (opts = {}) {
  * @param {HoverOptions} opts
  */
 commands.macosHover = async function macosHover (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/wda/element/${uuid}/hover` : '/wda/hover';
   return await this.wda.proxy.command(url, 'POST', {
@@ -257,7 +266,7 @@ commands.macosHover = async function macosHover (opts = {}) {
  * @param {DoubleClickOptions} opts
  */
 commands.macosDoubleClick = async function macosDoubleClick (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const { x, y, keyModifierFlags } = opts;
   const url = uuid ? `/wda/element/${uuid}/doubleClick` : '/wda/doubleClick';
   return await this.wda.proxy.command(url, 'POST', {
@@ -291,8 +300,8 @@ commands.macosDoubleClick = async function macosDoubleClick (opts = {}) {
  * @param {ClickAndDragOptions} opts
  */
 commands.macosClickAndDrag = async function macosClickAndDrag (opts = {}) {
-  const sourceUuid = requireUuid(opts, ['sourceElementId', 'sourceElement']);
-  const destUuid = requireUuid(opts, ['destinationElementId', 'destinationElement']);
+  const sourceUuid = extractUuid(opts, ['sourceElementId', 'sourceElement']);
+  const destUuid = extractUuid(opts, ['destinationElementId', 'destinationElement']);
   const {
     startX, startY,
     endX, endY,
@@ -341,8 +350,8 @@ commands.macosClickAndDrag = async function macosClickAndDrag (opts = {}) {
  * @param {ClickDragAndHoldOptions} opts
  */
 commands.macosClickDragAndHold = async function macosClickDragAndHold (opts = {}) {
-  const sourceUuid = requireUuid(opts, ['sourceElementId', 'sourceElement']);
-  const destUuid = requireUuid(opts, ['destinationElementId', 'destinationElement']);
+  const sourceUuid = extractUuid(opts, ['sourceElementId', 'sourceElement']);
+  const destUuid = extractUuid(opts, ['destinationElementId', 'destinationElement']);
   const {
     startX, startY,
     endX, endY,
@@ -391,7 +400,7 @@ commands.macosClickDragAndHold = async function macosClickDragAndHold (opts = {}
  * @param {KeysOptions} opts
  */
 commands.macosKeys = async function macosKeys (opts = {}) {
-  const uuid = requireUuid(opts);
+  const uuid = extractUuid(opts);
   const { keys } = opts;
   const url = uuid ? `/wda/element/${uuid}/keys` : '/wda/keys';
   return await this.wda.proxy.command(url, 'POST', { keys });

--- a/test/functional/interaction-e2e-specs.js
+++ b/test/functional/interaction-e2e-specs.js
@@ -87,7 +87,7 @@ describe('Mac2Driver - elements interaction', function () {
     const el = await driver.elementByClassName('XCUIElementTypeTextView');
     const flagsCtrl = 1 << 2;
     await driver.execute('macos: click', {
-      element: el,
+      elementId: el,
       keyModifierFlags: flagsCtrl,
     });
     const els = await driver.elements('-ios predicate string', `title == 'Import Image'`);


### PR DESCRIPTION
These gestures are now [available](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes) since Xcode 13 beta.
I've also changed the name of `element` arg, since some clients perform implicit replacement on it