### PR TITLE
fix: make sure to transpile index.js (fix #109)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ let boilerplate = require('@appium/gulp-plugins').boilerplate.use(gulp);
 
 boilerplate({
   build: 'appium-mac2-driver',
+  files: ['index.js', 'lib/**/*.js', 'test/**/*.js', '!gulpfile.js'],
   coverage: {
     files: ['./test/unit/**/*-specs.js', '!./test/functional/**'],
     verbose: true


### PR DESCRIPTION
should probably make this a default for gulp-plugins then undo here.