### PR TITLE
feat: Add a mobile endpoint to retrieve screenshots for each macOS display

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,12 @@ Base64-encoded content of the recorded media file if `remotePath` parameter is f
 
 Retrieves a screenshot of each display available to macOS.
 
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+displayId | number | no | Display identifier to take a screenshot for. If not provided then all display screenshots are going to be returned. If no matches were found then an error is thrown. | 1
+
 #### Returns
 
 A dictionary where each key contains a unique display identifier

--- a/README.md
+++ b/README.md
@@ -490,6 +490,18 @@ formFields | Map or `Array<Pair>` | no | Additional form fields for multipart ht
 
 Base64-encoded content of the recorded media file if `remotePath` parameter is falsy or an empty string.
 
+### macos: screenshots
+
+Retrieves a screenshot of each display available to macOS.
+
+#### Returns
+
+A dictionary where each key contains a unique display identifier
+and values are dictionaries with following items:
+- `id`: Display identifier
+- `isMain`: Whether this display is the main one
+- `payload`: The actual PNG screenshot data encoded to base64 string
+
 
 ## Application Under Test Concept
 

--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBScreenshotCommands.m
@@ -21,6 +21,9 @@
   @[
     [[FBRoute GET:@"/screenshot"].withoutSession respondWithTarget:self action:@selector(handleGetScreenshot:)],
     [[FBRoute GET:@"/screenshot"] respondWithTarget:self action:@selector(handleGetScreenshot:)],
+
+    [[FBRoute GET:@"/wda/screenshots"].withoutSession respondWithTarget:self action:@selector(handleGetScreenshots:)],
+    [[FBRoute GET:@"/wda/screenshots"] respondWithTarget:self action:@selector(handleGetScreenshots:)],
   ];
 }
 
@@ -37,6 +40,23 @@
   }
   NSString *screenshot = [screenshotData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
   return FBResponseWithObject(screenshot);
+}
+
++ (id<FBResponsePayload>)handleGetScreenshots:(FBRouteRequest *)request
+{
+  NSMutableDictionary <NSNumber *, NSDictionary *> *result = [NSMutableDictionary new];
+  for (XCUIScreen *screen in XCUIScreen.screens) {
+    NSNumber *displayId = [screen valueForKey:@"_displayID"];
+    NSNumber *isMainDisplay = [screen valueForKey:@"_isMainScreen"];
+    NSData *screenshotData = screen.screenshot.PNGRepresentation;
+    NSDictionary *screenInfo = @{
+      @"id": displayId == nil ? @(-1) : displayId,
+      @"isMain": isMainDisplay == nil ? @(NO) : isMainDisplay,
+      @"payload": screenshotData == nil ? NSNull.null : [screenshotData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]
+    };
+    [result setObject:screenInfo forKey:displayId];
+  }
+  return FBResponseWithObject(result);
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcuserdata/elf.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcuserdata/elf.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -13,9 +13,9 @@
             continueAfterRunningActions = "No"
             filePath = "WebDriverAgentLib/Commands/FBScreenshotCommands.m"
             startingColumnNumber = "90"
-            endingColumnNumber = "109"
-            startingLineNumber = "22"
-            endingLineNumber = "22"
+            endingColumnNumber = "90"
+            startingLineNumber = "23"
+            endingLineNumber = "23"
             landmarkName = "+routes"
             landmarkType = "7">
          </BreakpointContent>

--- a/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcuserdata/elf.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/xcuserdata/elf.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "EB05C65E-1678-400C-AEEC-EE53AC4C3816"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "557A20AB-411F-42C4-B430-CF99CB25F1D3"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "WebDriverAgentLib/Commands/FBScreenshotCommands.m"
+            startingColumnNumber = "90"
+            endingColumnNumber = "109"
+            startingLineNumber = "22"
+            endingLineNumber = "22"
+            landmarkName = "+routes"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -33,6 +33,8 @@ const EXTENSION_COMMANDS_MAPPING = {
 
   startRecordingScreen: 'startRecordingScreen',
   stopRecordingScreen: 'stopRecordingScreen',
+
+  screenshots: 'macosScreenshots',
 };
 
 commands.execute = async function execute (script, args) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -5,6 +5,7 @@ import sourceCmds from './source';
 import appManagementCmds from './app-management';
 import appleScriptCmds from './applescript';
 import screenRecordingCmds from './record-screen';
+import screenshotsCmds from './screenshots';
 
 const commands = {};
 Object.assign(
@@ -16,6 +17,7 @@ Object.assign(
   appManagementCmds,
   appleScriptCmds,
   screenRecordingCmds,
+  screenshotsCmds,
   // add other command types here
 );
 

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -11,12 +11,21 @@ const commands = {};
  */
 
 /**
+ * @typedef {Object} ScreenshotsOpts
+ * @property {number?} macOS Display identifier to take a screenshot for.
+ * If not provided then all display screenshots are going to be returned.
+ * If no matches were found then an error is thrown.
+ */
+
+/**
  * Retrieves screenshots of each display available to macOS
  *
+ * @param {ScreenshotsOpts} opts
  * @returns {ScreenshotsInfo}
  */
-commands.macosScreenshots = async function macosScreenshots () {
-  return await this.wda.proxy.command('/wda/screenshots', 'GET');
+commands.macosScreenshots = async function macosScreenshots (opts = {}) {
+  const {displayId} = opts;
+  return await this.wda.proxy.command('/wda/screenshots', 'POST', {id: displayId});
 };
 
 export { commands };

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -1,0 +1,23 @@
+const commands = {};
+
+/**
+ * @typedef {Object} ScreenshotsInfo
+ *
+ * A dictionary where each key contains a unique display identifier
+ * and values are dictionaries with following items:
+ * - id: Display identifier
+ * - isMain: Whether this display is the main one
+ * - payload: The actual PNG screenshot data encoded to base64 string
+ */
+
+/**
+ * Retrieves screenshots of each display available to macOS
+ *
+ * @returns {ScreenshotsInfo}
+ */
+commands.macosScreenshots = async function macosScreenshots () {
+  return await this.wda.proxy.command('/wda/screenshots', 'GET');
+};
+
+export { commands };
+export default commands;


### PR DESCRIPTION
There should be a possibility to take screenshots of multiple displays. The existing API only covers the main one