### PR TITLE
chore: Add an explicit getWindowRect for the images plugin

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -90,6 +90,11 @@ export class Mac2Driver extends BaseDriver {
     return await this.wda?.proxy?.command('/status', 'GET');
   }
 
+  // needed to make image plugin work
+  async getWindowRect () {
+    return await this.wda?.proxy?.command('/window/rect', 'GET');
+  }
+
   // @ts-ignore TODO: make args typed
   async createSession (...args) {
     // @ts-ignore TODO: make args typed


### PR DESCRIPTION
the plugin needs this API to be defined in order to be able to calculate dimensions