### PR TITLE
ci: use GH Action for detecting LTS Node

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,17 +1,27 @@
 name: Unit Tests
 
-on: [pull_request, push]
+on:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+    - 'docs/**'
+    - '*.md'
+  push:
+    branches: [ master ]
+    paths-ignore:
+    - 'docs/**'
+    - '*.md'
 
 
 jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.generate-matrix.outputs.versions }}
+      versions: ${{ steps.generate-matrix.outputs.active }}
     steps:
-    - name: Select 3 most recent LTS versions of Node.js
+    - name: Select all active LTS versions of Node.js
       id: generate-matrix
-      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:3] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
+      uses: msimerson/node-lts-versions@v1
 
   test:
     needs:


### PR DESCRIPTION
Same as https://github.com/appium/appium/pull/20059
Also adjust unit tests to be skipped for Markdown file changes and non-master branches.