### PR TITLE
fix: Optional Automation Mode user authentication check

### DIFF
--- a/lib/doctor/optional-checks.js
+++ b/lib/doctor/optional-checks.js
@@ -44,14 +44,14 @@ export class OptionalAutomationModeCheck {
     } catch (err) {
       return doctor.nokOptional(`Cannot run 'automationmodetool': ${err.stderr || err.message}`);
     }
-    if (stdout.includes('disabled')) {
-      return doctor.nokOptional(`Automation Mode is disabled`);
+    if (stdout.includes('DOES NOT REQUIRE')) {
+      return doctor.okOptional(`Automation Mode does not require user authentication`);
     }
-    return doctor.okOptional(`Automation Mode is enabled`);
+    return doctor.nokOptional(`Automation Mode requires user authentication`);
   }
 
   async fix() {
-    return `Run \`automationmodetool enable-automationmode-without-authentication\` to enable Automation Mode`;
+    return `Run \`automationmodetool enable-automationmode-without-authentication\` to disable Automation Mode authentication`;
   }
 
   hasAutofix() {


### PR DESCRIPTION
Users running `appium driver doctor mac2` are warned to run `automationmodetool enable-automationmode-without-authentication` based on whether the system is in Automation Mode at the time of the check, not whether user authentication is required for it. From the `automationmodetool` man page:
> If no argument is passed, the tool prints the current status of Automation Mode (enabled or disabled), the authentication configuration (required or not), and then exits.

Example:
```
% automationmodetool
Automation Mode is disabled.
This device DOES NOT REQUIRE user authentication to enable Automation Mode.
```
This PR changes the stdout check to 'DOES NOT REQUIRE' and inverts the warning logic.

Note: This code is untested. I do not have a local development environment for Appium or Appium drivers.