### PR TITLE
fix: Support non-strict XPath queries

### DIFF
--- a/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
@@ -78,7 +78,7 @@
 
 - (void)testSingleDescendantWithXPath
 {
-  NSString *query = @"*//XCUIElementTypeButton[starts-with(@identifier, \"_XCUI:\")]";
+  NSString *query = @"//XCUIElementTypeButton[starts-with(@identifier, \"_XCUI:\")]";
   NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingXPathQuery:query
                                                                  shouldReturnAfterFirstMatch:YES];
   XCTAssertEqual(matches.count, 1);

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
@@ -110,11 +110,10 @@
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:replacePattern
                                                                          options:NSRegularExpressionCaseInsensitive
                                                                            error:nil];
-  NSString *result = [regex stringByReplacingMatchesInString:self
+  return [regex stringByReplacingMatchesInString:self
                                          options:0
                                            range:NSMakeRange(0, [self length])
                                     withTemplate:@"$1.$2"];
-  return result;
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
@@ -93,6 +93,32 @@
 
 @end
 
+@interface NSString (FBXPathFixes)
+
+/**
+ https://discuss.appium.io/t/cannot-find-element-with-mac2/44959
+ */
+- (NSString *)fb_toFixedXPathQuery;
+
+@end
+
+@implementation NSString (FBXPathFixes)
+
+- (NSString *)fb_toFixedXPathQuery
+{
+  NSString *replacePattern = @"^([(]*)(/)";
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:replacePattern
+                                                                         options:NSRegularExpressionCaseInsensitive
+                                                                           error:nil];
+  NSString *result = [regex stringByReplacingMatchesInString:self
+                                         options:0
+                                           range:NSMakeRange(0, [self length])
+                                    withTemplate:@"$1.$2"];
+  return result;
+}
+
+@end
+
 static NSString *const kXMLIndexPathKey = @"private_indexPath";
 
 
@@ -132,7 +158,8 @@ static NSString *const kXMLIndexPathKey = @"private_indexPath";
 
   NSXMLElement *rootElement = [self makeXmlWithRootSnapshot:snapshot
                                                   indexPath:[AMSnapshotUtils hashWithSnapshot:snapshot]];
-  NSArray<__kindof NSXMLNode *> *matches = [rootElement nodesForXPath:xpathQuery error:&error];
+  NSArray<__kindof NSXMLNode *> *matches = [rootElement nodesForXPath:[xpathQuery fb_toFixedXPathQuery]
+                                                                error:&error];
   if (nil == matches) {
     @throw [NSException exceptionWithName:FBInvalidXPathException
                                    reason:error.description


### PR DESCRIPTION
Addresses https://discuss.appium.io/t/cannot-find-element-with-mac2/44959

In order to maintain the compatibility with the previously used libxml2 parser we need to "manually" patch incoming queries and make sure they always have the parent element type set. This is related to the fact NSXMLDocument's parser is strict and does not support the loose `//node` syntax, but requires `*/node` or `./node` instead