### PR TITLE
feat: Add support of executeMethodMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ object result = driver.ExecuteScript("macos: <methodName>", new Dictionary<strin
 });
 ```
 
+### maccos: setValue
+
+# TODO
+
 ### macos: click
 
 Perform click gesture on an element or by relative/absolute coordinates

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { errors } from 'appium/driver';
 
 const EXTENSION_COMMANDS_MAPPING = {
-  click: 'macosClick',
   scroll: 'macosScroll',
   swipe: 'macosSwipe',
   rightClick: 'macosRightClick',

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { errors } from 'appium/driver';
 
 const EXTENSION_COMMANDS_MAPPING = {
-  setValue: 'macosSetValue',
   click: 'macosClick',
   scroll: 'macosScroll',
   swipe: 'macosSwipe',

--- a/lib/commands/gestures.js
+++ b/lib/commands/gestures.js
@@ -37,12 +37,16 @@ function requireUuid (options = {}, keyNames = ['elementId', 'element']) {
  * Set value to the given element
  *
  * @this {Mac2Driver}
- * @param {import('../types').SetValueOptions} opts
+ * @param {string} elementId Uuid of the element to set value for.
+ * @param {any?} value Value to set. Could also be an array.
+ * @param {string?} text Text to set. If both value and text are set then `value` is preferred
+ * @param {number?} keyModifierFlags If set then the given key modifiers will
+ *                  be applied while the element value is being set. See
+ *                  https://developer.apple.com/documentation/xctest/xcuikeymodifierflags
+ *                  for more details.
  */
-export async function macosSetValue (opts) {
-  const uuid = requireUuid(opts);
-  const { value, text, keyModifierFlags } = opts ?? {};
-  return await this.wda.proxy.command(`/element/${uuid}/value`, 'POST', {
+export async function macosSetValue (elementId, value, text, keyModifierFlags) {
+  return await this.wda.proxy.command(`/element/${elementId}/value`, 'POST', {
     value, text,
     keyModifierFlags,
   });

--- a/lib/commands/gestures.js
+++ b/lib/commands/gestures.js
@@ -56,12 +56,19 @@ export async function macosSetValue (elementId, value, text, keyModifierFlags) {
  * Perform click gesture on an element or by relative/absolute coordinates
  *
  * @this {Mac2Driver}
- * @param {import('../types').ClickOptions} opts
+ * @param {string?} elementId Uuid of the element to click. Either this property
+ *                  or/and x and y must be set. If both are set then x and y are
+ *                  considered as relative element coordinates. If only x and y
+ *                  are set then these are parsed as absolute coordinates.
+ * @param {number?} x Click X coordinate
+ * @param {number?} y Click Y coordinate
+ * @param {number?} keyModifierFlags If set then the given key modifiers will be
+ *                  applied while click is performed. See
+ *                  https://developer.apple.com/documentation/xctest/xcuikeymodifierflags
+ *                  for more details
  */
-export async function macosClick (opts = {}) {
-  const uuid = extractUuid(opts);
-  const { x, y, keyModifierFlags } = opts;
-  const url = uuid ? `/element/${uuid}/click` : '/wda/click';
+export async function macosClick (elementId, x, y, keyModifierFlags) {
+  const url = elementId ? `/element/${elementId}/click` : '/wda/click';
   return await this.wda.proxy.command(url, 'POST', {
     x, y,
     keyModifierFlags,

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -1,17 +1,29 @@
 import { ExecuteMethodMap } from "@appium/types";
 
 export const executeMethodMap = {
-    'macos: setValue': {
-      command: 'macosSetValue',
-      params: {
-        required: [
-            'elementId'
-        ],
-        optional: [
-          'value',
-          'text',
-          'keyModifierFlags',
-        ],
-      },
+  'macos: setValue': {
+    command: 'macosSetValue',
+    params: {
+      required: [
+          'elementId'
+      ],
+      optional: [
+        'value',
+        'text',
+        'keyModifierFlags',
+      ],
     },
-} as const satisfies ExecuteMethodMap<any>;
+  },
+  'macos: click': {
+    command: 'macosClick',
+    params: {
+      required: [
+          'elementId'
+      ],
+      optional: [
+        'x',
+        'y',
+        'keyModifierFlags',
+      ],
+    },
+  },} as const satisfies ExecuteMethodMap<any>;

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -1,0 +1,17 @@
+import { ExecuteMethodMap } from "@appium/types";
+
+export const executeMethodMap = {
+    'macos: setValue': {
+      command: 'macosSetValue',
+      params: {
+        required: [
+            'elementId'
+        ],
+        optional: [
+          'value',
+          'text',
+          'keyModifierFlags',
+        ],
+      },
+    },
+} as const satisfies ExecuteMethodMap<any>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -89,31 +89,6 @@ export interface ExecAppleScriptOptions {
   cwd?: string;
 }
 
-export interface ClickOptions {
-  /**
-   * Uuid of the element to click. Either this property
-   * or/and x and y must be set. If both are set then x and y are considered as relative
-   * element coordinates. If only x and y are set then these are parsed as
-   * absolute coordinates.
-   */
-  elementId?: string;
-  /**
-   * Click X coordinate
-   */
-  x?: number;
-  /**
-   * Click Y coordinate
-   */
-  y?: number;
-  /**
-   * If set then the given key modifiers will be
-   * applied while click is performed. See
-   * https://developer.apple.com/documentation/xctest/xcuikeymodifierflags
-   * for more details
-   */
-  keyModifierFlags?: number;
-}
-
 export interface ScrollOptions {
   /**
    * Uuid of the element to be scrolled. Either this property

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -89,29 +89,6 @@ export interface ExecAppleScriptOptions {
   cwd?: string;
 }
 
-export interface SetValueOptions {
-  /**
-   * Uuid of the element to set value for
-   */
-  elementId: string;
-  /**
-   * Value to set. Could also be an array
-   */
-  value?: any;
-  /**
-   * Text to set. If both value and text are set
-   * then `value` is preferred
-   */
-  text?: string;
-  /**
-   * If set then the given key modifiers will be
-   * applied while the element value is being set. See
-   * https://developer.apple.com/documentation/xctest/xcuikeymodifierflags
-   * for more details
-   */
-  keyModifierFlags?: number;
-}
-
 export interface ClickOptions {
   /**
    * Uuid of the element to click. Either this property


### PR DESCRIPTION
Still wip

BREAKING CHANGE: Arguments of the following driver methods were changed:
- macosSetValue
- macosClick
- macosScroll