### PR TITLE
feat: locate WKWebView web elements by DOM id via AXDOMIdentifier (opt-in)

### DIFF
--- a/WebDriverAgentMac/IntegrationTests/AMElementAttributesTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMElementAttributesTests.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 
 #import "AMIntegrationTestCase.h"
+#import "FBConfiguration.h"
 #import "FBTestMacros.h"
 #import "XCUIElement+AMAttributes.h"
 #import "XCUIElement+AMEditable.h"
@@ -74,6 +75,19 @@
   XCTAssertFalse(hasFocus);
   NSInteger type = [[button am_wdAttributeValueWithName:@"elementType"] integerValue];
   XCTAssertEqual(type, XCUIElementTypeButton);
+}
+
+- (void)testIdentifierAttributeWhileDomIdFallbackIsEnabled
+{
+  XCUIElement *closeButton = [self.testedApplication.buttons matchingIdentifier:@"_XCUI:CloseWindow"].firstMatch;
+  FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = YES;
+  @try {
+    // A native identifier must never be replaced by a DOM one
+    NSString *identifier = [closeButton am_wdAttributeValueWithName:@"identifier"];
+    XCTAssertEqualObjects(identifier, @"_XCUI:CloseWindow");
+  } @finally {
+    FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = NO;
+  }
 }
 
 - (void)testDisabledAttribute

--- a/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 
 #import "AMIntegrationTestCase.h"
+#import "FBConfiguration.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBClassChain.h"
 
@@ -41,6 +42,25 @@
                                                                  shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matches.count, 1);
   XCTAssertEqualObjects(matches.firstObject.identifier, @"_XCUI:CloseWindow");
+}
+
+- (void)testSingleDescendantWithIdentifierWhileDomIdFallbackIsEnabled
+{
+  FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = YES;
+  @try {
+    // The application under test hosts no web content, so the fallback must find
+    // nothing extra and native identifiers must keep resolving as usual
+    NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingIdentifier:@"_XCUI:CloseWindow"
+                                                                   shouldReturnAfterFirstMatch:NO];
+    XCTAssertEqual(matches.count, 1);
+    XCTAssertEqualObjects(matches.firstObject.identifier, @"_XCUI:CloseWindow");
+
+    NSArray<XCUIElement *> *noMatches = [self.testedApplication fb_descendantsMatchingIdentifier:@"there_is_no_such_dom_id"
+                                                                     shouldReturnAfterFirstMatch:NO];
+    XCTAssertEqual(noMatches.count, 0);
+  } @finally {
+    FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = NO;
+  }
 }
 
 - (void)testSingleDescendantWithClassName

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.h
@@ -50,6 +50,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)am_hasKeyboardInputFocus;
 
+/**
+ The element's identifier as WebDriver reports it: the standard accessibility
+ identifier, falling back to the WebKit DOM identifier for web nodes, which leave the
+ standard one empty. The fallback only applies while useDomIdAsAccessibilityId is
+ enabled, and only takes a snapshot when it is actually needed.
+
+ @return The identifier. Could be an empty string
+ */
+- (NSString *)am_wdIdentifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
@@ -51,17 +51,23 @@
   } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, value)]) {
     return [FBElementUtils stringValueWithValue:self.value];
   } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, identifier)]) {
-    NSString *identifier = self.identifier;
-    if (identifier.length > 0 || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
-      return identifier;
-    }
-    return [AMSnapshotUtils wdIdentifierWithSnapshot:[self snapshotWithError:nil]] ?: identifier;
+    return self.am_wdIdentifier;
   }
   // This should not happen
   NSString *description = [NSString stringWithFormat:@"The attribute '%@' is unknown", wdAttributeName];
   @throw [NSException exceptionWithName:FBElementAttributeUnknownException
                                  reason:description
                                userInfo:@{}];
+}
+
+- (NSString *)am_wdIdentifier
+{
+  NSString *identifier = self.identifier;
+  // Snapshotting is not free, so only pay for it when the fallback can apply.
+  if (identifier.length > 0 || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
+    return identifier;
+  }
+  return [AMSnapshotUtils wdIdentifierWithSnapshot:[self snapshotWithError:nil]] ?: identifier;
 }
 
 - (NSDictionary<NSString *, NSNumber *> *)am_rect

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
@@ -17,6 +17,7 @@
 #import "XCUIElement+AMAttributes.h"
 
 #import "AMGeometryUtils.h"
+#import "AMSnapshotUtils.h"
 #import "FBConfiguration.h"
 #import "FBElementTypeTransformer.h"
 #import "FBElementUtils.h"
@@ -50,7 +51,20 @@
   } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, value)]) {
     return [FBElementUtils stringValueWithValue:self.value];
   } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, identifier)]) {
-    return self.identifier;
+    NSString *identifier = self.identifier;
+    // WebKit web nodes leave the standard AXIdentifier empty and publish their
+    // DOM `id` through AXDOMIdentifier. Report it, so elements found by DOM id
+    // also read back a stable identifier. Empty-only, so a native identifier is
+    // never overridden.
+    if (0 == identifier.length
+        && FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
+        && [AMSnapshotUtils isAccessibilityTrusted]) {
+      NSString *domIdentifier = [AMSnapshotUtils domIdentifierWithSnapshot:[self snapshotWithError:nil]];
+      if (domIdentifier.length > 0) {
+        return domIdentifier;
+      }
+    }
+    return identifier;
   }
   // This should not happen
   NSString *description = [NSString stringWithFormat:@"The attribute '%@' is unknown", wdAttributeName];

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
@@ -52,19 +52,10 @@
     return [FBElementUtils stringValueWithValue:self.value];
   } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, identifier)]) {
     NSString *identifier = self.identifier;
-    // WebKit web nodes leave the standard AXIdentifier empty and publish their
-    // DOM `id` through AXDOMIdentifier. Report it, so elements found by DOM id
-    // also read back a stable identifier. Empty-only, so a native identifier is
-    // never overridden.
-    if (0 == identifier.length
-        && FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
-        && [AMSnapshotUtils isAccessibilityTrusted]) {
-      NSString *domIdentifier = [AMSnapshotUtils domIdentifierWithSnapshot:[self snapshotWithError:nil]];
-      if (domIdentifier.length > 0) {
-        return domIdentifier;
-      }
+    if (identifier.length > 0 || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
+      return identifier;
     }
-    return identifier;
+    return [AMSnapshotUtils wdIdentifierWithSnapshot:[self snapshotWithError:nil]] ?: identifier;
   }
   // This should not happen
   NSString *description = [NSString stringWithFormat:@"The attribute '%@' is unknown", wdAttributeName];

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -19,28 +19,33 @@
 #import "XCUIElementQuery+AMHelpers.h"
 
 /**
- Walks an in-memory snapshot tree and collects the hashes of nodes whose WebKit
- DOM identifier equals the given value.
+ Collects the hashes of snapshot tree nodes whose identifier equals the given value.
  */
-static void AMCollectDomIdentifierMatches(id<XCUIElementSnapshot> snapshot,
-                                          NSString *accessibilityId,
-                                          BOOL firstMatchOnly,
-                                          NSMutableArray<NSString *> *matchedHashes)
+static void AMCollectIdentifierMatches(id<XCUIElementSnapshot> snapshot,
+                                       NSString *accessibilityId,
+                                       BOOL firstMatchOnly,
+                                       NSMutableArray<NSString *> *matchedHashes)
 {
   if (nil == snapshot || (firstMatchOnly && matchedHashes.count > 0)) {
     return;
   }
-  NSString *domIdentifier = [AMSnapshotUtils domIdentifierWithSnapshot:snapshot];
-  if (nil != domIdentifier && [domIdentifier isEqualToString:accessibilityId]) {
+  if ([[AMSnapshotUtils wdIdentifierWithSnapshot:snapshot] isEqualToString:accessibilityId]) {
     [matchedHashes addObject:[AMSnapshotUtils hashWithSnapshot:snapshot]];
     if (firstMatchOnly) {
       return;
     }
   }
   for (id<XCUIElementSnapshot> child in snapshot.children) {
-    AMCollectDomIdentifierMatches(child, accessibilityId, firstMatchOnly, matchedHashes);
+    AMCollectIdentifierMatches(child, accessibilityId, firstMatchOnly, matchedHashes);
   }
 }
+
+@interface XCUIElement (FBFindPrivate)
+
+- (NSArray<XCUIElement *> *)am_descendantsMatchingDomIdentifier:(NSString *)accessibilityId
+                                    shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch;
+
+@end
 
 @implementation XCUIElement (FBFind)
 
@@ -124,48 +129,31 @@ static void AMCollectDomIdentifierMatches(id<XCUIElementSnapshot> snapshot,
                                                   shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
   if (result.count > 0
       || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
-      || ![AMSnapshotUtils isAccessibilityTrusted]) {
+      || !AMSnapshotUtils.isAccessibilityTrusted) {
     return result.copy;
   }
+  // WebKit leaves the standard accessibility identifier of web nodes empty, so the
+  // above query cannot match them. Retry through their DOM identifiers.
+  return [self am_descendantsMatchingDomIdentifier:accessibilityId
+                       shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+}
 
-  // Fallback for WebKit (WKWebView) web content. XCUIElement.identifier maps to
-  // the standard AXIdentifier attribute, which WebKit leaves empty for web
-  // nodes, publishing the element's HTML `id` through the non-standard
-  // AXDOMIdentifier attribute instead. Match against that, so web content is
-  // locatable by accessibility id the same way as on other platforms.
-  //
-  // This only runs when the setting is enabled, the native match set is empty
-  // (native identifiers always win) and the process is Accessibility-trusted,
-  // so locating native elements is never affected.
-  //
-  // Take a single root snapshot and walk it in memory, then resolve just the
-  // matching nodes back to elements with one hash predicate query, which is the
-  // same technique the XPath search uses. Binding every descendant up front and
-  // snapshotting each one separately is orders of magnitude slower and exceeds
-  // the request timeout on large web trees.
+- (NSArray<XCUIElement *> *)am_descendantsMatchingDomIdentifier:(NSString *)accessibilityId
+                                    shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
+{
+  // Walk a single root snapshot in memory and only resolve the matching nodes back
+  // to elements. Binding every descendant up front and snapshotting each one
+  // separately exceeds the request timeout on large web trees.
   id<XCUIElementSnapshot> rootSnapshot = [self snapshotWithError:nil];
   if (nil == rootSnapshot) {
-    return result.copy;
+    return @[];
   }
   NSMutableArray<NSString *> *matchedHashes = [NSMutableArray array];
-  AMCollectDomIdentifierMatches(rootSnapshot, accessibilityId, shouldReturnAfterFirstMatch, matchedHashes);
-  if (0 == matchedHashes.count) {
-    return result.copy;
-  }
-  if ([matchedHashes containsObject:[AMSnapshotUtils hashWithSnapshot:rootSnapshot]]) {
-    [result addObject:self];
-    if (shouldReturnAfterFirstMatch) {
-      return result.copy;
-    }
-  }
-  NSPredicate *hashPredicate = [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
-    return [matchedHashes containsObject:[AMSnapshotUtils hashWithSnapshot:snapshot]];
-  }];
-  XCUIElementQuery *domQuery = [[self descendantsMatchingType:XCUIElementTypeAny]
-                                matchingPredicate:hashPredicate];
-  [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:domQuery
-                                                  shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
-  return result.copy;
+  AMCollectIdentifierMatches(rootSnapshot, accessibilityId, shouldReturnAfterFirstMatch, matchedHashes);
+  return [AMSnapshotUtils elementsWithHashes:matchedHashes.copy
+                                 rootElement:self
+                                rootSnapshot:rootSnapshot
+                       includeOnlyFirstMatch:shouldReturnAfterFirstMatch];
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -9,11 +9,38 @@
 
 #import "XCUIElement+FBFind.h"
 
+#import "AMSnapshotUtils.h"
+
+#import "FBConfiguration.h"
 #import "FBElementTypeTransformer.h"
 #import "FBElementUtils.h"
 #import "FBXPath.h"
 #import "NSPredicate+FBFormat.h"
 #import "XCUIElementQuery+AMHelpers.h"
+
+/**
+ Walks an in-memory snapshot tree and collects the hashes of nodes whose WebKit
+ DOM identifier equals the given value.
+ */
+static void AMCollectDomIdentifierMatches(id<XCUIElementSnapshot> snapshot,
+                                          NSString *accessibilityId,
+                                          BOOL firstMatchOnly,
+                                          NSMutableArray<NSString *> *matchedHashes)
+{
+  if (nil == snapshot || (firstMatchOnly && matchedHashes.count > 0)) {
+    return;
+  }
+  NSString *domIdentifier = [AMSnapshotUtils domIdentifierWithSnapshot:snapshot];
+  if (nil != domIdentifier && [domIdentifier isEqualToString:accessibilityId]) {
+    [matchedHashes addObject:[AMSnapshotUtils hashWithSnapshot:snapshot]];
+    if (firstMatchOnly) {
+      return;
+    }
+  }
+  for (id<XCUIElementSnapshot> child in snapshot.children) {
+    AMCollectDomIdentifierMatches(child, accessibilityId, firstMatchOnly, matchedHashes);
+  }
+}
 
 @implementation XCUIElement (FBFind)
 
@@ -94,6 +121,49 @@
   }
   XCUIElementQuery *query = [[self descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:accessibilityId];
   [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query
+                                                  shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
+  if (result.count > 0
+      || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
+      || ![AMSnapshotUtils isAccessibilityTrusted]) {
+    return result.copy;
+  }
+
+  // Fallback for WebKit (WKWebView) web content. XCUIElement.identifier maps to
+  // the standard AXIdentifier attribute, which WebKit leaves empty for web
+  // nodes, publishing the element's HTML `id` through the non-standard
+  // AXDOMIdentifier attribute instead. Match against that, so web content is
+  // locatable by accessibility id the same way as on other platforms.
+  //
+  // This only runs when the setting is enabled, the native match set is empty
+  // (native identifiers always win) and the process is Accessibility-trusted,
+  // so locating native elements is never affected.
+  //
+  // Take a single root snapshot and walk it in memory, then resolve just the
+  // matching nodes back to elements with one hash predicate query, which is the
+  // same technique the XPath search uses. Binding every descendant up front and
+  // snapshotting each one separately is orders of magnitude slower and exceeds
+  // the request timeout on large web trees.
+  id<XCUIElementSnapshot> rootSnapshot = [self snapshotWithError:nil];
+  if (nil == rootSnapshot) {
+    return result.copy;
+  }
+  NSMutableArray<NSString *> *matchedHashes = [NSMutableArray array];
+  AMCollectDomIdentifierMatches(rootSnapshot, accessibilityId, shouldReturnAfterFirstMatch, matchedHashes);
+  if (0 == matchedHashes.count) {
+    return result.copy;
+  }
+  if ([matchedHashes containsObject:[AMSnapshotUtils hashWithSnapshot:rootSnapshot]]) {
+    [result addObject:self];
+    if (shouldReturnAfterFirstMatch) {
+      return result.copy;
+    }
+  }
+  NSPredicate *hashPredicate = [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
+    return [matchedHashes containsObject:[AMSnapshotUtils hashWithSnapshot:snapshot]];
+  }];
+  XCUIElementQuery *domQuery = [[self descendantsMatchingType:XCUIElementTypeAny]
+                                matchingPredicate:hashPredicate];
+  [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:domQuery
                                                   shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
   return result.copy;
 }

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -20,24 +20,30 @@
 
 /**
  Collects the hashes of snapshot tree nodes whose identifier equals the given value.
+
+ @return YES if the caller should stop descending, which happens as soon as a match is
+ found while only the first one is wanted
  */
-static void AMCollectIdentifierMatches(id<XCUIElementSnapshot> snapshot,
+static BOOL AMCollectIdentifierMatches(id<XCUIElementSnapshot> snapshot,
                                        NSString *accessibilityId,
                                        BOOL firstMatchOnly,
-                                       NSMutableArray<NSString *> *matchedHashes)
+                                       NSMutableSet<NSString *> *matchedHashes)
 {
-  if (nil == snapshot || (firstMatchOnly && matchedHashes.count > 0)) {
-    return;
+  if (nil == snapshot) {
+    return NO;
   }
   if ([[AMSnapshotUtils wdIdentifierWithSnapshot:snapshot] isEqualToString:accessibilityId]) {
     [matchedHashes addObject:[AMSnapshotUtils hashWithSnapshot:snapshot]];
     if (firstMatchOnly) {
-      return;
+      return YES;
     }
   }
   for (id<XCUIElementSnapshot> child in snapshot.children) {
-    AMCollectIdentifierMatches(child, accessibilityId, firstMatchOnly, matchedHashes);
+    if (AMCollectIdentifierMatches(child, accessibilityId, firstMatchOnly, matchedHashes)) {
+      return YES;
+    }
   }
+  return NO;
 }
 
 @interface XCUIElement (FBFindPrivate)
@@ -128,8 +134,7 @@ static void AMCollectIdentifierMatches(id<XCUIElementSnapshot> snapshot,
   [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query
                                                   shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
   if (result.count > 0
-      || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
-      || !AMSnapshotUtils.isAccessibilityTrusted) {
+      || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
     return result.copy;
   }
   // WebKit leaves the standard accessibility identifier of web nodes empty, so the
@@ -148,7 +153,7 @@ static void AMCollectIdentifierMatches(id<XCUIElementSnapshot> snapshot,
   if (nil == rootSnapshot) {
     return @[];
   }
-  NSMutableArray<NSString *> *matchedHashes = [NSMutableArray array];
+  NSMutableSet<NSString *> *matchedHashes = [NSMutableSet set];
   AMCollectIdentifierMatches(rootSnapshot, accessibilityId, shouldReturnAfterFirstMatch, matchedHashes);
   return [AMSnapshotUtils elementsWithHashes:matchedHashes.copy
                                  rootElement:self

--- a/WebDriverAgentMac/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -238,6 +238,7 @@ const static NSString *CAPABILITIES_KEY = @"capabilities";
       AM_BOUND_ELEMENTS_BY_INDEX_SETTING: @(FBSession.activeSession.boundElementsByIndex),
       AM_USE_DEFAULT_UI_INTERRUPTIONS_HANDLING_SETTING: @(!application.am_doesNotHandleUIInterruptions),
       AM_FETCH_FULL_TEXT: @(FBConfiguration.sharedConfiguration.fetchFullText),
+      AM_USE_DOM_ID_AS_ACCESSIBILITY_ID: @(FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId),
     }
   );
 }
@@ -255,6 +256,10 @@ const static NSString *CAPABILITIES_KEY = @"capabilities";
   }
   if (nil != [settings objectForKey:AM_FETCH_FULL_TEXT]) {
     FBConfiguration.sharedConfiguration.fetchFullText = [settings objectForKey:AM_FETCH_FULL_TEXT];
+  }
+  if (nil != [settings objectForKey:AM_USE_DOM_ID_AS_ACCESSIBILITY_ID]) {
+    FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId =
+      [[settings objectForKey:AM_USE_DOM_ID_AS_ACCESSIBILITY_ID] boolValue];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSettings.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSettings.h
@@ -28,4 +28,7 @@ extern NSString* const AM_USE_DEFAULT_UI_INTERRUPTIONS_HANDLING_SETTING;
 /*! Whether to use custom snapshotting mechanism to fetch full element's text payload instead of the first 512 chars  */
 extern NSString* const AM_FETCH_FULL_TEXT;
 
+/*! Whether to expose a WKWebView web element's DOM id as its accessibility id */
+extern NSString* const AM_USE_DOM_ID_AS_ACCESSIBILITY_ID;
+
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSettings.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSettings.m
@@ -19,3 +19,4 @@
 NSString* const AM_BOUND_ELEMENTS_BY_INDEX_SETTING = @"boundElementsByIndex";
 NSString* const AM_USE_DEFAULT_UI_INTERRUPTIONS_HANDLING_SETTING = @"useDefaultUiInterruptionsHandling";
 NSString* const AM_FETCH_FULL_TEXT = @"fetchFullText";
+NSString* const AM_USE_DOM_ID_AS_ACCESSIBILITY_ID = @"useDomIdAsAccessibilityId";

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
@@ -31,26 +31,42 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)hashWithSnapshot:(id)snapshot;
 
 /**
- Whether the current process is trusted for the public Accessibility API.
- When NO, DOM identifier resolution is impossible, because attribute reads
- fail with kAXErrorAPIDisabled, and callers must fall back to the default
- behaviour.
+ Retrieves the identifier WebDriver clients should observe for the given snapshot.
+ This is the standard accessibility identifier, except for WebKit (WKWebView) web
+ nodes, which leave it empty and publish their HTML `id` through the non-standard
+ AXDOMIdentifier attribute instead. That one is only consulted while the
+ `useDomIdAsAccessibilityId` setting is enabled, so a native identifier is never
+ overridden.
+
+ @param snapshot snapshot instance to retrieve the identifier for
+ @return The identifier value or nil
+ */
++ (nullable NSString *)wdIdentifierWithSnapshot:(nullable id<XCUIElementSnapshot>)snapshot;
+
+/**
+ Whether this process may use the public Accessibility API, which DOM identifier
+ resolution depends on. XCUITest does NOT depend on it, so an untrusted runner keeps
+ automating native content normally while every AXDOMIdentifier read fails with
+ kAXErrorAPIDisabled. Callers use this to skip work that cannot succeed. The value is
+ cached, since TCC trust is fixed at process start.
 
  @return YES if the process may use the Accessibility API
  */
 + (BOOL)isAccessibilityTrusted;
 
 /**
- Retrieves the DOM identifier of a WebKit (WKWebView) web element, by
- reconstituting the underlying accessibility element from the snapshot's remote
- token and reading its non-standard AXDOMIdentifier attribute. WebKit publishes
- an element's HTML `id` there, while leaving the standard AXIdentifier empty.
+ Resolves snapshot hashes back to live elements below the given root element.
 
- @param snapshot snapshot instance to resolve the DOM identifier for
- @return The DOM identifier, or nil for native elements, for elements without
- an `id`, and whenever the process is not Accessibility-trusted
+ @param hashes snapshot hashes to resolve, as returned by hashWithSnapshot:
+ @param rootElement the element the hashes were collected from
+ @param rootSnapshot the snapshot of rootElement
+ @param firstMatch whether to only return the first matching element
+ @return The matching elements. Could be empty
  */
-+ (nullable NSString *)domIdentifierWithSnapshot:(id)snapshot;
++ (NSArray<XCUIElement *> *)elementsWithHashes:(NSArray<NSString *> *)hashes
+                                   rootElement:(XCUIElement *)rootElement
+                                  rootSnapshot:(id<XCUIElementSnapshot>)rootSnapshot
+                         includeOnlyFirstMatch:(BOOL)firstMatch;
 
 @end
 

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
@@ -30,6 +30,28 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSString *)hashWithSnapshot:(id)snapshot;
 
+/**
+ Whether the current process is trusted for the public Accessibility API.
+ When NO, DOM identifier resolution is impossible, because attribute reads
+ fail with kAXErrorAPIDisabled, and callers must fall back to the default
+ behaviour.
+
+ @return YES if the process may use the Accessibility API
+ */
++ (BOOL)isAccessibilityTrusted;
+
+/**
+ Retrieves the DOM identifier of a WebKit (WKWebView) web element, by
+ reconstituting the underlying accessibility element from the snapshot's remote
+ token and reading its non-standard AXDOMIdentifier attribute. WebKit publishes
+ an element's HTML `id` there, while leaving the standard AXIdentifier empty.
+
+ @param snapshot snapshot instance to resolve the DOM identifier for
+ @return The DOM identifier, or nil for native elements, for elements without
+ an `id`, and whenever the process is not Accessibility-trusted
+ */
++ (nullable NSString *)domIdentifierWithSnapshot:(id)snapshot;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
@@ -44,17 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString *)wdIdentifierWithSnapshot:(nullable id<XCUIElementSnapshot>)snapshot;
 
 /**
- Whether this process may use the public Accessibility API, which DOM identifier
- resolution depends on. XCUITest does NOT depend on it, so an untrusted runner keeps
- automating native content normally while every AXDOMIdentifier read fails with
- kAXErrorAPIDisabled. Callers use this to skip work that cannot succeed. The value is
- cached, since TCC trust is fixed at process start.
-
- @return YES if the process may use the Accessibility API
- */
-+ (BOOL)isAccessibilityTrusted;
-
-/**
  Resolves snapshot hashes back to live elements below the given root element.
 
  @param hashes snapshot hashes to resolve, as returned by hashWithSnapshot:
@@ -63,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param firstMatch whether to only return the first matching element
  @return The matching elements. Could be empty
  */
-+ (NSArray<XCUIElement *> *)elementsWithHashes:(NSArray<NSString *> *)hashes
++ (NSArray<XCUIElement *> *)elementsWithHashes:(NSSet<NSString *> *)hashes
                                    rootElement:(XCUIElement *)rootElement
                                   rootSnapshot:(id<XCUIElementSnapshot>)rootSnapshot
                          includeOnlyFirstMatch:(BOOL)firstMatch;

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
@@ -47,10 +47,10 @@ static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
 
 /**
  Whether this process may use the public Accessibility API. XCUITest itself does not
- need it, so an untrusted runner automates natively just fine while every
- AXDOMIdentifier read fails with kAXErrorAPIDisabled — checking up front keeps that
- case from walking whole element trees for nothing. TCC trust is fixed at process
- start, so the answer cannot change under us and is worth caching.
+ need it, so an untrusted runner keeps automating native content normally while every
+ AXDOMIdentifier read fails with kAXErrorAPIDisabled. Guarding the read turns a failing
+ syscall per element into a cached boolean. TCC trust is fixed at process start, so the
+ answer cannot change under us.
  */
 static BOOL AMIsAccessibilityTrusted(void)
 {
@@ -90,19 +90,13 @@ static BOOL AMIsAccessibilityTrusted(void)
 {
   NSString *identifier = snapshot.identifier;
   if (identifier.length > 0
-      || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
-      || !AMIsAccessibilityTrusted()) {
+      || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
     return identifier;
   }
   return [self domIdentifierWithSnapshot:snapshot] ?: identifier;
 }
 
-+ (BOOL)isAccessibilityTrusted
-{
-  return AMIsAccessibilityTrusted();
-}
-
-+ (NSArray<XCUIElement *> *)elementsWithHashes:(NSArray<NSString *> *)hashes
++ (NSArray<XCUIElement *> *)elementsWithHashes:(NSSet<NSString *> *)hashes
                                    rootElement:(XCUIElement *)rootElement
                                   rootSnapshot:(id<XCUIElementSnapshot>)rootSnapshot
                          includeOnlyFirstMatch:(BOOL)firstMatch
@@ -130,7 +124,7 @@ static BOOL AMIsAccessibilityTrusted(void)
 
 + (nullable NSString *)domIdentifierWithSnapshot:(nullable id)snapshot
 {
-  if (nil == snapshot) {
+  if (nil == snapshot || !AMIsAccessibilityTrusted()) {
     return nil;
   }
   AMCreateWithRemoteTokenFn createRef = AMRemoteTokenFn();

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
@@ -16,12 +16,87 @@
 
 #import "AMSnapshotUtils.h"
 
+#import <dlfcn.h>
+
+#import "FBLogger.h"
+
+static NSString *const AM_DOM_IDENTIFIER_ATTRIBUTE = @"AXDOMIdentifier";
+
+/**
+ Creates an AXUIElementRef from an accessibility element's remote token.
+
+ This entry point is not exported in the public link stubs, so it is resolved
+ dynamically. The underscore-prefixed name is the one actually present in the
+ framework; the unprefixed name is tried as a fallback.
+ */
+typedef AXUIElementRef _Nullable (*AMCreateWithRemoteTokenFn)(CFDataRef);
+
+static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
+{
+  static AMCreateWithRemoteTokenFn fn = NULL;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    fn = (AMCreateWithRemoteTokenFn)dlsym(RTLD_DEFAULT, "_AXUIElementCreateWithRemoteToken");
+    if (NULL == fn) {
+      fn = (AMCreateWithRemoteTokenFn)dlsym(RTLD_DEFAULT, "AXUIElementCreateWithRemoteToken");
+    }
+  });
+  return fn;
+}
+
 @implementation AMSnapshotUtils
 
 + (NSString *)hashWithSnapshot:(id)snapshot
 {
   NSData *token = [[snapshot valueForKey:@"_accessibilityElement"] valueForKey:@"_token"];
   return [token base64EncodedStringWithOptions:0];
+}
+
++ (BOOL)isAccessibilityTrusted
+{
+  return AXIsProcessTrusted();
+}
+
++ (nullable NSString *)domIdentifierWithSnapshot:(id)snapshot
+{
+  if (nil == snapshot || !AXIsProcessTrusted()) {
+    return nil;
+  }
+  AMCreateWithRemoteTokenFn createRef = AMRemoteTokenFn();
+  if (NULL == createRef) {
+    return nil;
+  }
+
+  @try {
+    NSData *token = [[snapshot valueForKey:@"_accessibilityElement"] valueForKey:@"_token"];
+    if (![token isKindOfClass:NSData.class]) {
+      return nil;
+    }
+    AXUIElementRef ref = createRef((__bridge CFDataRef)token);
+    if (NULL == ref) {
+      return nil;
+    }
+    CFTypeRef value = NULL;
+    AXError err = AXUIElementCopyAttributeValue(ref,
+                                                (__bridge CFStringRef)AM_DOM_IDENTIFIER_ATTRIBUTE,
+                                                &value);
+    CFRelease(ref);
+    // Native (non-web) elements report kAXErrorAttributeUnsupported here.
+    if (kAXErrorSuccess != err || NULL == value) {
+      return nil;
+    }
+    NSString *result = [(__bridge id)value isKindOfClass:NSString.class]
+      ? [(__bridge NSString *)value copy]
+      : nil;
+    CFRelease(value);
+    return result.length > 0 ? result : nil;
+  } @catch (NSException *e) {
+    // The private key path (_accessibilityElement._token) is the only reason a
+    // catch is needed. A throw means that internal layout changed, which is
+    // worth surfacing rather than swallowing silently.
+    [FBLogger logFmt:@"Cannot retrieve the DOM identifier of a snapshot. Original error: %@", e.reason];
+    return nil;
+  }
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
@@ -37,10 +37,8 @@ static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
   static AMCreateWithRemoteTokenFn fn = NULL;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    fn = (AMCreateWithRemoteTokenFn)dlsym(RTLD_DEFAULT, "_AXUIElementCreateWithRemoteToken");
-    if (NULL == fn) {
-      fn = (AMCreateWithRemoteTokenFn)dlsym(RTLD_DEFAULT, "AXUIElementCreateWithRemoteToken");
-    }
+    fn = (AMCreateWithRemoteTokenFn)(dlsym(RTLD_DEFAULT, "_AXUIElementCreateWithRemoteToken")
+                                     ?: dlsym(RTLD_DEFAULT, "AXUIElementCreateWithRemoteToken"));
   });
   return fn;
 }

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
@@ -16,18 +16,19 @@
 
 #import "AMSnapshotUtils.h"
 
+#import <ApplicationServices/ApplicationServices.h>
 #import <dlfcn.h>
 
+#import "FBConfiguration.h"
 #import "FBLogger.h"
+#import "XCUIElementQuery+AMHelpers.h"
 
 static NSString *const AM_DOM_IDENTIFIER_ATTRIBUTE = @"AXDOMIdentifier";
 
 /**
- Creates an AXUIElementRef from an accessibility element's remote token.
-
- This entry point is not exported in the public link stubs, so it is resolved
- dynamically. The underscore-prefixed name is the one actually present in the
- framework; the unprefixed name is tried as a fallback.
+ Creates an AXUIElementRef from an accessibility element's remote token. This entry
+ point is not exported in the public link stubs, so it is resolved dynamically. The
+ underscore-prefixed name is the one actually present in the framework.
  */
 typedef AXUIElementRef _Nullable (*AMCreateWithRemoteTokenFn)(CFDataRef);
 
@@ -44,6 +45,39 @@ static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
   return fn;
 }
 
+/**
+ Whether this process may use the public Accessibility API. XCUITest itself does not
+ need it, so an untrusted runner automates natively just fine while every
+ AXDOMIdentifier read fails with kAXErrorAPIDisabled — checking up front keeps that
+ case from walking whole element trees for nothing. TCC trust is fixed at process
+ start, so the answer cannot change under us and is worth caching.
+ */
+static BOOL AMIsAccessibilityTrusted(void)
+{
+  static BOOL isTrusted = NO;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    isTrusted = AXIsProcessTrusted();
+    if (!isTrusted) {
+      [FBLogger log:@"This process is not trusted for the Accessibility API, so WebKit DOM "
+       @"identifiers cannot be resolved. Grant Accessibility permission to the "
+       @"WebDriverAgentRunner app and restart it to enable useDomIdAsAccessibilityId."];
+    }
+  });
+  return isTrusted;
+}
+
+@interface AMSnapshotUtils ()
+
+/**
+ Reads the non-standard AXDOMIdentifier attribute, where WebKit publishes a web
+ node's HTML `id`. Returns nil for native elements, which report
+ kAXErrorAttributeUnsupported for it.
+ */
++ (nullable NSString *)domIdentifierWithSnapshot:(nullable id)snapshot;
+
+@end
+
 @implementation AMSnapshotUtils
 
 + (NSString *)hashWithSnapshot:(id)snapshot
@@ -52,14 +86,51 @@ static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
   return [token base64EncodedStringWithOptions:0];
 }
 
-+ (BOOL)isAccessibilityTrusted
++ (nullable NSString *)wdIdentifierWithSnapshot:(nullable id<XCUIElementSnapshot>)snapshot
 {
-  return AXIsProcessTrusted();
+  NSString *identifier = snapshot.identifier;
+  if (identifier.length > 0
+      || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
+      || !AMIsAccessibilityTrusted()) {
+    return identifier;
+  }
+  return [self domIdentifierWithSnapshot:snapshot] ?: identifier;
 }
 
-+ (nullable NSString *)domIdentifierWithSnapshot:(id)snapshot
++ (BOOL)isAccessibilityTrusted
 {
-  if (nil == snapshot || !AXIsProcessTrusted()) {
+  return AMIsAccessibilityTrusted();
+}
+
++ (NSArray<XCUIElement *> *)elementsWithHashes:(NSArray<NSString *> *)hashes
+                                   rootElement:(XCUIElement *)rootElement
+                                  rootSnapshot:(id<XCUIElementSnapshot>)rootSnapshot
+                         includeOnlyFirstMatch:(BOOL)firstMatch
+{
+  if (0 == hashes.count) {
+    return @[];
+  }
+
+  NSMutableArray<XCUIElement *> *matchingElements = [NSMutableArray array];
+  if ([hashes containsObject:[self hashWithSnapshot:rootSnapshot]]) {
+    [matchingElements addObject:rootElement];
+    if (firstMatch) {
+      return matchingElements.copy;
+    }
+  }
+  NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
+    return [hashes containsObject:[self hashWithSnapshot:snapshot]];
+  }];
+  [matchingElements addObjectsFromArray:[[rootElement descendantsMatchingType:XCUIElementTypeAny]
+                                         matchingPredicate:predicate].am_allMatches];
+  return firstMatch && matchingElements.count > 0
+    ? @[matchingElements.firstObject]
+    : matchingElements.copy;
+}
+
++ (nullable NSString *)domIdentifierWithSnapshot:(nullable id)snapshot
+{
+  if (nil == snapshot) {
     return nil;
   }
   AMCreateWithRemoteTokenFn createRef = AMRemoteTokenFn();
@@ -81,7 +152,6 @@ static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
                                                 (__bridge CFStringRef)AM_DOM_IDENTIFIER_ATTRIBUTE,
                                                 &value);
     CFRelease(ref);
-    // Native (non-web) elements report kAXErrorAttributeUnsupported here.
     if (kAXErrorSuccess != err || NULL == value) {
       return nil;
     }
@@ -91,9 +161,7 @@ static AMCreateWithRemoteTokenFn AMRemoteTokenFn(void)
     CFRelease(value);
     return result.length > 0 ? result : nil;
   } @catch (NSException *e) {
-    // The private key path (_accessibilityElement._token) is the only reason a
-    // catch is needed. A throw means that internal layout changed, which is
-    // worth surfacing rather than swallowing silently.
+    // Only the private _accessibilityElement._token key path may throw here
     [FBLogger logFmt:@"Cannot retrieve the DOM identifier of a snapshot. Original error: %@", e.reason];
     return nil;
   }

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -33,6 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Whether to use custom snapshotting mechanism to fetch full element's text payload instead of the first 512 chars  */
 @property BOOL fetchFullText;
 
+/*! Whether to expose a WKWebView web element's DOM id as its accessibility id */
+@property BOOL useDomIdAsAccessibilityId;
+
 /**
  The range of ports that the HTTP Server should attempt to bind on launch
  */

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -12,6 +12,7 @@
 static NSUInteger const DefaultStartingPort = 10100;
 static NSUInteger const DefaultPortRange = 100;
 static BOOL FBFetchFullText = NO;
+static BOOL FBUseDomIdAsAccessibilityId = NO;
 
 @implementation FBConfiguration
 
@@ -84,6 +85,16 @@ static FBConfiguration *instance;
 - (void)setFetchFullText:(BOOL)fetchFullText
 {
   FBFetchFullText = fetchFullText;
+}
+
+- (BOOL)useDomIdAsAccessibilityId
+{
+  return FBUseDomIdAsAccessibilityId;
+}
+
+- (void)setUseDomIdAsAccessibilityId:(BOOL)useDomIdAsAccessibilityId
+{
+  FBUseDomIdAsAccessibilityId = useDomIdAsAccessibilityId;
 }
 
 - (NSRange)bindingPortRange

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
@@ -184,7 +184,7 @@ static NSString *const kXMLIndexPathKey = @"private_indexPath";
     return @[];
   }
 
-  NSMutableArray<NSString *> *hashes = [NSMutableArray array];
+  NSMutableSet<NSString *> *hashes = [NSMutableSet set];
   for (NSXMLNode *node in nodes) {
     if (![node isKindOfClass:NSXMLElement.class]) {
       continue;

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
@@ -195,21 +195,10 @@ static NSString *const kXMLIndexPathKey = @"private_indexPath";
     }
     [hashes addObject:attrValue];
   }
-  NSMutableArray<XCUIElement *> *matchingElements = [NSMutableArray array];
-  NSString *selfHash = [AMSnapshotUtils hashWithSnapshot:rootSnapshot];
-  if ([hashes containsObject:selfHash]) {
-    [matchingElements addObject:rootElement];
-    if (firstMatch) {
-      return matchingElements.copy;
-    }
-  }
-  NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
-    return [hashes containsObject:[AMSnapshotUtils hashWithSnapshot:snapshot]];
-  }];
-  [matchingElements addObjectsFromArray:[[rootElement descendantsMatchingType:XCUIElementTypeAny] matchingPredicate:predicate].am_allMatches];
-  return firstMatch && matchingElements.count > 0
-    ? @[matchingElements.firstObject]
-    : matchingElements.copy;
+  return [AMSnapshotUtils elementsWithHashes:hashes.copy
+                                 rootElement:rootElement
+                                rootSnapshot:rootSnapshot
+                       includeOnlyFirstMatch:firstMatch];
 }
 
 + (NSXMLDocument *)xmlRepresentationWithSnapshot:(id<XCUIElementSnapshot>)root
@@ -366,19 +355,7 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
 
 + (NSString *)valueForElement:(id<XCUIElementSnapshot>)element
 {
-  NSString *identifier = element.identifier;
-  // Expose WebKit web nodes' DOM `id`, consistent with the find path and the
-  // element `identifier` attribute, so web content is visible when inspecting
-  // the page source. Empty-only, so native identifiers are never overridden.
-  if (0 == identifier.length
-      && FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
-      && [AMSnapshotUtils isAccessibilityTrusted]) {
-    NSString *domIdentifier = [AMSnapshotUtils domIdentifierWithSnapshot:element];
-    if (domIdentifier.length > 0) {
-      return domIdentifier;
-    }
-  }
-  return identifier;
+  return [AMSnapshotUtils wdIdentifierWithSnapshot:element];
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBXPath.m
@@ -366,7 +366,19 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
 
 + (NSString *)valueForElement:(id<XCUIElementSnapshot>)element
 {
-  return element.identifier;
+  NSString *identifier = element.identifier;
+  // Expose WebKit web nodes' DOM `id`, consistent with the find path and the
+  // element `identifier` attribute, so web content is visible when inspecting
+  // the page source. Empty-only, so native identifiers are never overridden.
+  if (0 == identifier.length
+      && FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId
+      && [AMSnapshotUtils isAccessibilityTrusted]) {
+    NSString *domIdentifier = [AMSnapshotUtils domIdentifierWithSnapshot:element];
+    if (domIdentifier.length > 0) {
+      return domIdentifier;
+    }
+  }
+  return identifier;
 }
 
 @end

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -47,3 +47,31 @@ Whether to use the standard XCTest UI interruption handler, as opposed to disabl
 Turning this off may be useful for scenarios that interact with the interrupting element itself,
 instead of having its view be implicitly closed. Refer to [this WWDC presentation](https://developer.apple.com/videos/play/wwdc2020/10220/)
 to learn more about handling UI interruptions.
+
+## useDomIdAsAccessibilityId
+
+| Type | Default |
+| -- | -- |
+| `boolean` | `false` |
+
+Whether to expose a `WKWebView` web element's DOM `id` as its accessibility identifier, so that
+web content can be located by `accessibility id` the same way as on other platforms.
+
+Web content rendered by WebKit does not populate the standard accessibility identifier
+(`AXIdentifier`) that the `accessibility id` locator matches. Instead it publishes the element's
+HTML `id` through the non-standard `AXDOMIdentifier` attribute. With this setting enabled the
+driver reads `AXDOMIdentifier` and uses it as a fallback for `accessibility id` lookups, for the
+`identifier` attribute and for the page source. The fallback only applies to elements whose native
+identifier is empty, so locating native elements is never affected.
+
+Notes:
+
+- The process running the WebDriverAgent runner must be granted Accessibility permission
+  (System Settings → Privacy & Security → Accessibility). Without it the underlying attribute
+  reads fail with `kAXErrorAPIDisabled` and the driver transparently keeps the default behaviour.
+- Enabling this makes `accessibility id` lookups that find no native match inspect the
+  application's web nodes, which costs an extra snapshot walk. That is why it is off by default.
+- WebKit builds a web view's accessibility subtree lazily, so the very first lookup after a page
+  appears may need a retry, or a page source request, before the web content is present.
+
+ Available since driver version 4.1.0.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -66,12 +66,7 @@ identifier is empty, so locating native elements is never affected.
 
 Notes:
 
-- The process running the WebDriverAgent runner must be granted Accessibility permission
-  (System Settings → Privacy & Security → Accessibility). Without it the underlying attribute
-  reads fail with `kAXErrorAPIDisabled` and the driver transparently keeps the default behaviour.
 - Enabling this makes `accessibility id` lookups that find no native match inspect the
   application's web nodes, which costs an extra snapshot walk. That is why it is off by default.
 - WebKit builds a web view's accessibility subtree lazily, so the very first lookup after a page
   appears may need a retry, or a page source request, before the web content is present.
-
- Available since driver version 4.1.0.


### PR DESCRIPTION
## Summary

Adds an **opt-in** `useDomIdAsAccessibilityId` setting (default `false`) that lets
web content inside a `WKWebView` be located by `accessibility id` using the
element's DOM `id` — the way the same elements are already locatable on Windows.

## Motivation

For hybrid macOS apps that host web content in a `WKWebView`, web elements cannot
currently be located by `accessibility id`. WebKit does **not** populate the
standard accessibility identifier (`AXIdentifier`) for web nodes; it exposes the
DOM `id` through a **non-standard** attribute, `AXDOMIdentifier`, which the
`accessibility id` locator does not read. Only `aria-label` (via the element's
name) is reachable today, which forces macOS-only locators that diverge from other
platforms. (On Windows, Chromium maps the DOM `id` to UIA `AutomationId`, so the
same locators already work there.)

## What this does

When `useDomIdAsAccessibilityId` is enabled, for each candidate element the driver
reconstitutes the underlying `AXUIElementRef` from the element snapshot's remote
token and reads `AXDOMIdentifier`, using it as an **empty-only fallback** in three
places:

- the `accessibility id` find path (`XCUIElement+FBFind`),
- the `identifier` attribute (`XCUIElement+AMAttributes`),
- the page-source XML (`FBXPath`, so Appium Inspector / xpath see it).

Native identifiers always take precedence (the fallback runs only when the native
match set is empty / the native identifier is empty), so **native element locating
is unchanged**. Native controls report `kAXErrorAttributeUnsupported` for
`AXDOMIdentifier`, which naturally yields "no DOM id".

## Requirements / trade-offs

- Uses the **public Accessibility API**, so the process running the WDA runner must
  be Accessibility-trusted. When it is not, reads return `kAXErrorAPIDisabled` and
  the driver **degrades gracefully** to the default behaviour (no errors, native
  locating unaffected).
- The fallback materializes and inspects web descendants, so it is **off by
  default** and intended for suites that locate web content by DOM `id`.
- The token → `AXUIElementRef` reconstruction uses the private
  `_AXUIElementCreateWithRemoteToken`, resolved via `dlsym` (not statically linked;
  the symbol is exported with a leading underscore on current macOS). Open to
  guidance if the project prefers a different approach here.

## Validation

- The bridge logic was validated end-to-end against a real Appium `mac2` session on
  **macOS 26.5 / Xcode 26.5** using a fixture app (WKWebView + an HTML id catalog):
  **9/9** checks — web-id resolution incl. **iframe** and **shadow DOM**, the found
  element reporting its `identifier`, duplicate-id first-match, dynamically-rendered
  element after interaction, the native-element regression, and a negative
  (`data-*` attributes, which WebKit never exposes, correctly do not match).
- This branch (v4.0.4 + the setting gate) **compiles clean** (`build-for-testing`).

## Docs

`docs/reference/settings.md` documents the new setting.

## Notes for reviewers

- Should the default remain `false` (opt-in), or is default-on acceptable given the
  empty-only + graceful-degradation design?
- Happy to add integration tests mirroring the existing `IntegrationTests` pattern
  if you'd like them in this PR.


---

### Update — validated against a real application

The feature has now been exercised against a production app whose in-meeting UI
is a `WKWebView` (RingCentral Video), not just a synthetic fixture. Five web
elements resolve by `accessibility id` through their DOM ids:

| locator | resolved element |
| -- | -- |
| `invite-btn` | "Invite participants" |
| `participants-btn` | "Show the participants list, 34 participants in meeting" |
| `chat-btn` | "Chat with everyone" |
| `hangup-btn` | "Leave meeting" |
| `microphone-btn` | "Unmute, currently muted" |

That exercise also surfaced a real defect in the first revision, fixed in
`38dc166`: the fallback bound every descendant as an `XCUIElement` and
re-snapshotted each one, which exceeded WebDriverAgent's request timeout on a
large web tree. It now takes one root snapshot, walks it in memory, and resolves
only the matching nodes via a single hash predicate query — the same technique
`FBXPath` uses. Lookups went from a 240 s timeout to roughly a second.

One behavioural note worth knowing (now documented in the settings reference):
WebKit builds a web view's accessibility subtree lazily, so the first lookup
after a page appears may need a retry.
