### PR TITLE
feat: locate WKWebView web elements via predicate string and class chain

### DIFF
--- a/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
@@ -22,6 +22,10 @@
 #import "XCUIElement+FBClassChain.h"
 
 
+static NSString *const AMWebContainerDomId = @"am-web-container";
+static NSString *const AMWebButtonDomId = @"am-dom-button";
+static NSTimeInterval const AMWebContentTimeout = 10.0;
+
 @interface AMFindElementTests : AMIntegrationTestCase
 @end
 
@@ -36,6 +40,34 @@
   });
 }
 
+- (void)tearDown
+{
+  // Other test classes assume the app is on the Buttons tab by default and do not
+  // switch to it themselves - restore it so tests that dwell on the WebView tab here
+  // do not leak that state into whichever test class happens to run next.
+  [self switchToButtonsTab];
+  [super tearDown];
+}
+
+/**
+ WebKit builds a web view's accessibility subtree lazily, so the very first lookup
+ after the page appears may need a retry before the web content shows up. Polls the
+ given lookup until it finds something or the timeout elapses.
+ */
+- (NSArray<XCUIElement *> *)am_waitForWebContentUsingBlock:(NSArray<XCUIElement *> *(^)(void))block
+{
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:AMWebContentTimeout];
+  NSArray<XCUIElement *> *matches = @[];
+  do {
+    matches = block();
+    if (matches.count > 0) {
+      return matches;
+    }
+    [NSThread sleepForTimeInterval:0.5];
+  } while ([deadline timeIntervalSinceNow] > 0);
+  return matches;
+}
+
 - (void)testSingleDescendantWithIdentifier
 {
   NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingIdentifier:@"_XCUI:CloseWindow"
@@ -46,10 +78,11 @@
 
 - (void)testSingleDescendantWithIdentifierWhileDomIdFallbackIsEnabled
 {
+  [self skipUnlessAccessibilityTrusted];
+  [self switchToWebViewTab];
   FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = YES;
   @try {
-    // The application under test hosts no web content, so the fallback must find
-    // nothing extra and native identifiers must keep resolving as usual
+    // Native identifiers must keep resolving as usual
     NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingIdentifier:@"_XCUI:CloseWindow"
                                                                    shouldReturnAfterFirstMatch:NO];
     XCTAssertEqual(matches.count, 1);
@@ -58,9 +91,26 @@
     NSArray<XCUIElement *> *noMatches = [self.testedApplication fb_descendantsMatchingIdentifier:@"there_is_no_such_dom_id"
                                                                      shouldReturnAfterFirstMatch:NO];
     XCTAssertEqual(noMatches.count, 0);
+
+    // The web button has no native accessibility identifier, only a DOM id - the
+    // fallback must resolve it
+    NSArray<XCUIElement *> *webMatches = [self am_waitForWebContentUsingBlock:^NSArray<XCUIElement *> * {
+      return [self.testedApplication fb_descendantsMatchingIdentifier:AMWebButtonDomId
+                                            shouldReturnAfterFirstMatch:NO];
+    }];
+    XCTAssertEqual(webMatches.count, 1);
+    XCTAssertEqual(webMatches.firstObject.elementType, XCUIElementTypeButton);
   } @finally {
     FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = NO;
   }
+}
+
+- (void)testSingleDescendantWithIdentifierFindsNothingForDomIdWhenFallbackIsDisabled
+{
+  [self switchToWebViewTab];
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingIdentifier:AMWebButtonDomId
+                                                                 shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 0);
 }
 
 - (void)testSingleDescendantWithClassName
@@ -142,6 +192,93 @@
   XCTAssertTrue(matches.count >= 3);
   XCTAssertEqualObjects(matches.firstObject.identifier, @"_XCUI:CloseWindow");
   XCTAssertEqualObjects([matches objectAtIndex:2].identifier, @"_XCUI:MinimizeWindow");
+}
+
+- (void)testSingleDescendantWithPredicateMatchingAmIdentifierWhileDomIdFallbackIsEnabled
+{
+  [self skipUnlessAccessibilityTrusted];
+  [self switchToWebViewTab];
+  FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = YES;
+  @try {
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"amIdentifier == %@ AND elementType == %lu",
+                              AMWebButtonDomId, XCUIElementTypeButton];
+    NSArray<XCUIElement *> *matches = [self am_waitForWebContentUsingBlock:^NSArray<XCUIElement *> * {
+      return [self.testedApplication fb_descendantsMatchingPredicate:predicate
+                                          shouldReturnAfterFirstMatch:NO];
+    }];
+    XCTAssertEqual(matches.count, 1);
+    XCTAssertEqual(matches.firstObject.elementType, XCUIElementTypeButton);
+  } @finally {
+    FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = NO;
+  }
+}
+
+- (void)testSingleDescendantWithPredicateAmIdentifierAliasesNativeIdentifierWhenFallbackIsDisabled
+{
+  // amIdentifier mirrors am_identifier: with the setting off it is just the native
+  // identifier, same as the standard identifier attribute
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"amIdentifier == %@", @"_XCUI:CloseWindow"];
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingPredicate:predicate
+                                                                shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 1);
+}
+
+- (void)testSingleDescendantWithPredicateAmIdentifierFindsNothingForDomIdWhenFallbackIsDisabled
+{
+  [self switchToWebViewTab];
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"amIdentifier == %@", AMWebButtonDomId];
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingPredicate:predicate
+                                                                shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 0);
+}
+
+- (void)testSingleDescendantWithClassChainMatchingAmIdentifierOnLastSegmentWhileDomIdFallbackIsEnabled
+{
+  [self skipUnlessAccessibilityTrusted];
+  [self switchToWebViewTab];
+  FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = YES;
+  @try {
+    NSString *query = [NSString stringWithFormat:@"**/XCUIElementTypeButton[`amIdentifier == '%@'`]", AMWebButtonDomId];
+    NSArray<XCUIElement *> *matches = [self am_waitForWebContentUsingBlock:^NSArray<XCUIElement *> * {
+      return [self.testedApplication fb_descendantsMatchingClassChain:query
+                                            shouldReturnAfterFirstMatch:NO];
+    }];
+    XCTAssertEqual(matches.count, 1);
+    XCTAssertEqual(matches.firstObject.elementType, XCUIElementTypeButton);
+  } @finally {
+    FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = NO;
+  }
+}
+
+- (void)testSingleDescendantWithClassChainMatchingAmIdentifierOnAncestorSegmentWhileDomIdFallbackIsEnabled
+{
+  [self skipUnlessAccessibilityTrusted];
+  [self switchToWebViewTab];
+  FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = YES;
+  @try {
+    // The amIdentifier predicate sits on a non-terminal (ancestor) segment here, not
+    // the last one - this works because every class chain segment's predicate is
+    // formatted through the same NSPredicate+FBFormat rewrite, regardless of position
+    NSString *query = [NSString stringWithFormat:@"**/XCUIElementTypeGroup[`amIdentifier == '%@'`]/XCUIElementTypeButton",
+                       AMWebContainerDomId];
+    NSArray<XCUIElement *> *matches = [self am_waitForWebContentUsingBlock:^NSArray<XCUIElement *> * {
+      return [self.testedApplication fb_descendantsMatchingClassChain:query
+                                            shouldReturnAfterFirstMatch:NO];
+    }];
+    XCTAssertEqual(matches.count, 1);
+    XCTAssertEqual(matches.firstObject.elementType, XCUIElementTypeButton);
+  } @finally {
+    FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId = NO;
+  }
+}
+
+- (void)testSingleDescendantWithClassChainAmIdentifierFindsNothingForDomIdWhenFallbackIsDisabled
+{
+  [self switchToWebViewTab];
+  NSString *query = [NSString stringWithFormat:@"**/XCUIElementTypeButton[`amIdentifier == '%@'`]", AMWebButtonDomId];
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingClassChain:query
+                                                                 shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 0);
 }
 
 @end

--- a/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
+++ b/WebDriverAgentMac/IntegrationTests/AMFindElementTests.m
@@ -18,6 +18,7 @@
 
 #import "AMIntegrationTestCase.h"
 #import "FBConfiguration.h"
+#import "XCUIElement+AMAttributes.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBClassChain.h"
 
@@ -230,6 +231,31 @@ static NSTimeInterval const AMWebContentTimeout = 10.0;
   NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingPredicate:predicate
                                                                 shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matches.count, 0);
+}
+
+- (void)testSingleDescendantWithPredicateMatchingNestedAmRectKeyPath
+{
+  // A nested key path into an am_* attribute's resolved value (amRect is a
+  // {x, y, width, height} dictionary) must resolve through the same block-predicate
+  // rewrite as a bare am_* reference, not fall through to native key path resolution.
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingIdentifier:@"_XCUI:CloseWindow"
+                                                                 shouldReturnAfterFirstMatch:YES];
+  XCTAssertEqual(matches.count, 1);
+  NSNumber *x = matches.firstObject.am_rect[@"x"];
+  XCTAssertNotNil(x);
+
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"identifier == %@ AND amRect.x == %@",
+                            @"_XCUI:CloseWindow", x];
+  NSArray<XCUIElement *> *nestedMatches = [self.testedApplication fb_descendantsMatchingPredicate:predicate
+                                                                        shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(nestedMatches.count, 1);
+  XCTAssertEqualObjects(nestedMatches.firstObject.identifier, @"_XCUI:CloseWindow");
+
+  NSPredicate *nonMatchingPredicate = [NSPredicate predicateWithFormat:@"identifier == %@ AND amRect.x == %@",
+                                       @"_XCUI:CloseWindow", @(x.doubleValue + 1000)];
+  NSArray<XCUIElement *> *noMatches = [self.testedApplication fb_descendantsMatchingPredicate:nonMatchingPredicate
+                                                                    shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(noMatches.count, 0);
 }
 
 - (void)testSingleDescendantWithClassChainMatchingAmIdentifierOnLastSegmentWhileDomIdFallbackIsEnabled

--- a/WebDriverAgentMac/IntegrationTests/AMIntegrationTestCase.h
+++ b/WebDriverAgentMac/IntegrationTests/AMIntegrationTestCase.h
@@ -32,6 +32,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)switchToEditsTab;
 
+- (void)switchToWebViewTab;
+
+/**
+ Skips the current test unless this process is trusted for the Accessibility API.
+ Tests that rely on the useDomIdAsAccessibilityId fallback need this - without it,
+ WebKit DOM identifier resolution silently returns nothing, which otherwise surfaces
+ as a confusing "found 0 elements" test failure rather than a clear "grant
+ Accessibility permission and re-run" skip reason.
+ */
+- (void)skipUnlessAccessibilityTrusted;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentMac/IntegrationTests/AMIntegrationTestCase.m
+++ b/WebDriverAgentMac/IntegrationTests/AMIntegrationTestCase.m
@@ -59,6 +59,25 @@
   [self.testedApplication.radioButtons[@"WebView"].firstMatch click];
 }
 
+/**
+ Reading AXDOMIdentifier (unlike ordinary XCTest snapshotting) goes through the macOS
+ Accessibility API, which requires the process to be trusted under System Settings > Privacy &
+ Security > Accessibility. Two things make that grant easy to lose track of while iterating
+ locally in Xcode:
+
+ - Ad-hoc code signing loses the grant on every rebuild. macOS ties an Accessibility grant to
+   the binary's signing identity (its CDHash), and the default ad-hoc signature
+   (Signature=adhoc, no Team ID) gets a new CDHash on every build. The permission then appears
+   to "not stick" - it was actually granted, just to a binary that no longer exists. Assigning
+   a stable signing identity (e.g. an "Apple Development" certificate under a real Team ID) in
+   the target's Signing & Capabilities keeps the CDHash constant across rebuilds, so the grant
+   persists. This has to be done for both the WebDriverAgent app target and the
+   IntegrationTests test bundle target - granting only one leaves the other still ad-hoc signed
+   and still losing trust every build.
+ - xcodebuild build alone does not regenerate the signed XCTRunner wrapper app that actually
+   hosts and runs the tests, so a plain build after a signing change can silently run against a
+   stale runner. Use build-for-testing (or test, or Xcode's own Test action) instead.
+ */
 - (void)skipUnlessAccessibilityTrusted
 {
   XCTSkipUnless(AMSnapshotUtils.isAccessibilityTrusted,

--- a/WebDriverAgentMac/IntegrationTests/AMIntegrationTestCase.m
+++ b/WebDriverAgentMac/IntegrationTests/AMIntegrationTestCase.m
@@ -16,6 +16,7 @@
 
 #import "AMIntegrationTestCase.h"
 
+#import "AMSnapshotUtils.h"
 #import "FBConfiguration.h"
 
 @interface AMIntegrationTestCase ()
@@ -51,6 +52,19 @@
 - (void)switchToEditsTab
 {
   [self.testedApplication.radioButtons[@"Edits"].firstMatch click];
+}
+
+- (void)switchToWebViewTab
+{
+  [self.testedApplication.radioButtons[@"WebView"].firstMatch click];
+}
+
+- (void)skipUnlessAccessibilityTrusted
+{
+  XCTSkipUnless(AMSnapshotUtils.isAccessibilityTrusted,
+               @"This process is not trusted for the Accessibility API. Grant Accessibility "
+               @"permission to it in System Settings > Privacy & Security > Accessibility "
+               @"(note: an ad-hoc-signed build's grant does not survive a rebuild), then re-run.");
 }
 
 @end

--- a/WebDriverAgentMac/WebDriverAgent/Base.lproj/Main.storyboard
+++ b/WebDriverAgentMac/WebDriverAgent/Base.lproj/Main.storyboard
@@ -685,7 +685,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" restorable="NO" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
@@ -709,6 +709,7 @@
                     <tabViewItems>
                         <tabViewItem identifier="" id="Mia-WI-iEB"/>
                         <tabViewItem identifier="" id="sIZ-jZ-jj9"/>
+                        <tabViewItem identifier="" id="Nlk-3F-Wcb"/>
                     </tabViewItems>
                     <tabView key="tabView" type="noTabsNoBorder" id="Rch-4v-RJW">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
@@ -722,6 +723,7 @@
                         <outlet property="tabView" destination="Rch-4v-RJW" id="1XV-Um-WgP"/>
                         <segue destination="Pkx-be-7b9" kind="relationship" relationship="tabItems" id="IJQ-4v-ZpO"/>
                         <segue destination="bnY-XE-5sK" kind="relationship" relationship="tabItems" id="MtI-PF-Enx"/>
+                        <segue destination="Qzv-6y-WKw" kind="relationship" relationship="tabItems" id="Pma-8s-CkV"/>
                     </connections>
                 </tabViewController>
                 <customObject id="iEe-Sq-WC0" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -831,6 +833,19 @@
                 <customObject id="TZC-Og-vHj" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="545" y="-408"/>
+        </scene>
+        <!--WebView-->
+        <scene sceneID="tGx-1M-hRz">
+            <objects>
+                <viewController title="WebView" id="Qzv-6y-WKw" customClass="WebViewController" sceneMemberID="viewController">
+                    <view key="view" id="Fbv-Y8-Enh">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="Xdm-hz-1Yc" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1075" y="-408"/>
         </scene>
     </scenes>
 </document>

--- a/WebDriverAgentMac/WebDriverAgent/WebViewController.h
+++ b/WebDriverAgentMac/WebDriverAgent/WebViewController.h
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+@interface WebViewController : NSViewController
+
+@end

--- a/WebDriverAgentMac/WebDriverAgent/WebViewController.m
+++ b/WebDriverAgentMac/WebDriverAgent/WebViewController.m
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "WebViewController.h"
+
+#import <WebKit/WebKit.h>
+
+/*
+ None of these elements set a native accessibility identifier, so WebKit leaves their
+ standard AXIdentifier empty and only exposes their DOM `id` through AXDOMIdentifier -
+ this mirrors real-world web content and is what useDomIdAsAccessibilityId is meant to
+ fall back onto.
+ */
+static NSString *const AMWebViewHTML =
+@"<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head><body>"
+@"<div id=\"am-web-container\" role=\"group\">"
+@"<button id=\"am-dom-button\">Web Button</button>"
+@"<span id=\"am-dom-text\">Web Text</span>"
+@"</div>"
+@"</body></html>";
+
+@implementation WebViewController
+
+- (void)loadView
+{
+  self.view = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 450, 300)];
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+
+  [(WKWebView *)self.view loadHTMLString:AMWebViewHTML baseURL:nil];
+}
+
+@end

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/NSPredicate+FBFormat.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/NSPredicate+FBFormat.m
@@ -10,6 +10,7 @@
 #import "NSPredicate+FBFormat.h"
 
 #import "NSExpression+FBFormat.h"
+#import "XCUIElement+AMAttributes.h"
 
 @implementation NSPredicate (FBFormat)
 
@@ -33,9 +34,73 @@
   return original;
 }
 
+/**
+ Whether the given expression is a key path referencing one of the am_* predicate
+ attributes (AM_IDENTIFIER_ATTRIBUTE_NAME and friends, see XCUIElement+AMAttributes).
+
+ @return The referenced am_* attribute name, or nil if it isn't one
+ */
++ (nullable NSString *)fb_amAttributeNameForExpression:(NSExpression *)expression
+{
+  if (NSKeyPathExpressionType != expression.expressionType) {
+    return nil;
+  }
+  NSString *keyPath = expression.keyPath;
+  return [[XCUIElement am_predicateAttributeNames] containsObject:keyPath] ? keyPath : nil;
+}
+
+/**
+ Rebuilds a comparison predicate that references an am_* attribute on one side into a
+ block predicate that resolves that attribute directly off the snapshot node being
+ matched and compares it with the same operator/options as the original. Block
+ predicates are evaluated per-node by matchingPredicate:/containingPredicate: (this is
+ how the accessibility id DOM fallback already resolves elements), unlike plain
+ comparison predicates whose key path resolution WebKit content does not reliably
+ observe.
+
+ @param cp the original comparison predicate, known to reference an am_* attribute
+ @param amAttributeName the am_* attribute name referenced
+ @param amAttributeOnLeft whether it is the left or the right expression
+ @return an equivalent block-based predicate
+ */
++ (NSPredicate *)fb_amAttributePredicateForComparison:(NSComparisonPredicate *)cp
+                                       amAttributeName:(NSString *)amAttributeName
+                                      amAttributeOnLeft:(BOOL)amAttributeOnLeft
+{
+  NSExpression *otherExpression = amAttributeOnLeft ? cp.rightExpression : cp.leftExpression;
+  NSComparisonPredicateModifier modifier = cp.comparisonPredicateModifier;
+  NSPredicateOperatorType operatorType = cp.predicateOperatorType;
+  NSComparisonPredicateOptions options = cp.options;
+  return [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
+    id amValue = [XCUIElement am_valueForPredicateAttributeName:amAttributeName target:snapshot] ?: @"";
+    id otherValue = [otherExpression expressionValueWithObject:snapshot context:nil];
+    NSExpression *amExpression = [NSExpression expressionForConstantValue:amValue];
+    NSExpression *otherConstantExpression = [NSExpression expressionForConstantValue:otherValue];
+    NSComparisonPredicate *rewritten = amAttributeOnLeft
+      ? [NSComparisonPredicate predicateWithLeftExpression:amExpression
+                                            rightExpression:otherConstantExpression
+                                                   modifier:modifier
+                                                       type:operatorType
+                                                    options:options]
+      : [NSComparisonPredicate predicateWithLeftExpression:otherConstantExpression
+                                            rightExpression:amExpression
+                                                   modifier:modifier
+                                                       type:operatorType
+                                                    options:options];
+    return [rewritten evaluateWithObject:nil];
+  }];
+}
+
 + (instancetype)fb_formatSearchPredicate:(NSPredicate *)input
 {
   return [self.class fb_predicateWithPredicate:input comparisonModifier:^NSPredicate *(NSComparisonPredicate *cp) {
+    NSString *leftAmAttribute = [self.class fb_amAttributeNameForExpression:cp.leftExpression];
+    NSString *rightAmAttribute = [self.class fb_amAttributeNameForExpression:cp.rightExpression];
+    if (nil != leftAmAttribute || nil != rightAmAttribute) {
+      return [self.class fb_amAttributePredicateForComparison:cp
+                                                amAttributeName:leftAmAttribute ?: rightAmAttribute
+                                              amAttributeOnLeft:nil != leftAmAttribute];
+    }
     NSExpression *left = [NSExpression fb_wdExpressionWithExpression:[cp leftExpression]];
     NSExpression *right = [NSExpression fb_wdExpressionWithExpression:[cp rightExpression]];
     return [NSComparisonPredicate predicateWithLeftExpression:left

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/NSPredicate+FBFormat.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/NSPredicate+FBFormat.m
@@ -73,7 +73,8 @@
   NSComparisonPredicateOptions options = cp.options;
   return [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
     id amValue = [XCUIElement am_valueForPredicateAttributeName:amAttributeName target:snapshot] ?: @"";
-    id otherValue = [otherExpression expressionValueWithObject:snapshot context:nil];
+    NSMutableDictionary *context = bindings ? [bindings mutableCopy] : [NSMutableDictionary dictionary];
+    id otherValue = [otherExpression expressionValueWithObject:snapshot context:context];
     NSExpression *amExpression = [NSExpression expressionForConstantValue:amValue];
     NSExpression *otherConstantExpression = [NSExpression expressionForConstantValue:otherValue];
     NSComparisonPredicate *rewritten = amAttributeOnLeft

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/NSPredicate+FBFormat.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/NSPredicate+FBFormat.m
@@ -36,7 +36,9 @@
 
 /**
  Whether the given expression is a key path referencing one of the am_* predicate
- attributes (AM_IDENTIFIER_ATTRIBUTE_NAME and friends, see XCUIElement+AMAttributes).
+ attributes (AM_IDENTIFIER_ATTRIBUTE_NAME and friends, see XCUIElement+AMAttributes),
+ either directly (`amRect`) or through a nested key path into its resolved value
+ (`amRect.x`).
 
  @return The referenced am_* attribute name, or nil if it isn't one
  */
@@ -46,7 +48,9 @@
     return nil;
   }
   NSString *keyPath = expression.keyPath;
-  return [[XCUIElement am_predicateAttributeNames] containsObject:keyPath] ? keyPath : nil;
+  NSUInteger dotPos = [keyPath rangeOfString:@"."].location;
+  NSString *attributeName = NSNotFound == dotPos ? keyPath : [keyPath substringToIndex:dotPos];
+  return [[XCUIElement am_predicateAttributeNames] containsObject:attributeName] ? attributeName : nil;
 }
 
 /**
@@ -56,7 +60,9 @@
  predicates are evaluated per-node by matchingPredicate:/containingPredicate: (this is
  how the accessibility id DOM fallback already resolves elements), unlike plain
  comparison predicates whose key path resolution WebKit content does not reliably
- observe.
+ observe. A nested key path into the attribute's resolved value (e.g. `amRect.x`) is
+ resolved with a plain valueForKeyPath: lookup after the attribute value itself is
+ resolved.
 
  @param cp the original comparison predicate, known to reference an am_* attribute
  @param amAttributeName the am_* attribute name referenced
@@ -67,12 +73,20 @@
                                        amAttributeName:(NSString *)amAttributeName
                                       amAttributeOnLeft:(BOOL)amAttributeOnLeft
 {
+  NSExpression *amAttributeExpression = amAttributeOnLeft ? cp.leftExpression : cp.rightExpression;
   NSExpression *otherExpression = amAttributeOnLeft ? cp.rightExpression : cp.leftExpression;
+  NSString *amKeyPath = amAttributeExpression.keyPath;
+  NSUInteger dotPos = [amKeyPath rangeOfString:@"."].location;
+  NSString *amValueKeyPathSuffix = NSNotFound == dotPos ? nil : [amKeyPath substringFromIndex:(dotPos + 1)];
   NSComparisonPredicateModifier modifier = cp.comparisonPredicateModifier;
   NSPredicateOperatorType operatorType = cp.predicateOperatorType;
   NSComparisonPredicateOptions options = cp.options;
   return [NSPredicate predicateWithBlock:^BOOL(id snapshot, NSDictionary *bindings) {
-    id amValue = [XCUIElement am_valueForPredicateAttributeName:amAttributeName target:snapshot] ?: @"";
+    id amValue = [XCUIElement am_valueForPredicateAttributeName:amAttributeName target:snapshot];
+    if (amValueKeyPathSuffix.length > 0) {
+      amValue = [amValue valueForKeyPath:amValueKeyPathSuffix];
+    }
+    amValue = amValue ?: @"";
     NSMutableDictionary *context = bindings ? [bindings mutableCopy] : [NSMutableDictionary dictionary];
     id otherValue = [otherExpression expressionValueWithObject:snapshot context:context];
     NSExpression *amExpression = [NSExpression expressionForConstantValue:amValue];

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.h
@@ -18,6 +18,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*!
+ Predicate string / class chain keypath names for the am_* attributes below. These are
+ non-standard, Mac2-driver-specific attributes, in addition to the standard
+ XCUIElementAttributes ones.
+ */
+extern NSString *const AM_IDENTIFIER_ATTRIBUTE_NAME;
+extern NSString *const AM_RECT_ATTRIBUTE_NAME;
+extern NSString *const AM_TEXT_ATTRIBUTE_NAME;
+extern NSString *const AM_TYPE_ATTRIBUTE_NAME;
+extern NSString *const AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME;
+
 @interface XCUIElement (AMAttributes)
 
 /**
@@ -58,7 +69,24 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return The identifier. Could be an empty string
  */
-- (NSString *)am_wdIdentifier;
+- (NSString *)am_identifier;
+
+/**
+ The full set of am_* predicate attribute names (AM_IDENTIFIER_ATTRIBUTE_NAME and
+ friends) usable in predicate string / class chain locators.
+ */
++ (NSArray<NSString *> *)am_predicateAttributeNames;
+
+/**
+ Resolves the value of an am_* predicate attribute name directly against a target,
+ which may be a live XCUIElement or a raw id<XCUIElementSnapshot> - the latter keeps
+ per-node predicate evaluation cheap by not needing to resolve a live element first.
+
+ @param name one of AM_IDENTIFIER_ATTRIBUTE_NAME and friends
+ @param target the XCUIElement or id<XCUIElementSnapshot> to resolve the value against
+ @return The resolved value, or nil if name is not a known am_* attribute name
+ */
++ (nullable id)am_valueForPredicateAttributeName:(NSString *)name target:(id)target;
 
 @end
 

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
@@ -25,6 +25,12 @@
 #import "FBMacros.h"
 #import "XCUIElementQuery+AMHelpers.h"
 
+NSString *const AM_IDENTIFIER_ATTRIBUTE_NAME = @"amIdentifier";
+NSString *const AM_RECT_ATTRIBUTE_NAME = @"amRect";
+NSString *const AM_TEXT_ATTRIBUTE_NAME = @"amText";
+NSString *const AM_TYPE_ATTRIBUTE_NAME = @"amType";
+NSString *const AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME = @"amHasKeyboardInputFocus";
+
 @implementation XCUIElement (AMAttributes)
 
 - (id)am_wdAttributeValueWithName:(NSString *)name
@@ -50,8 +56,17 @@
     return self.title;
   } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, value)]) {
     return [FBElementUtils stringValueWithValue:self.value];
-  } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, identifier)]) {
-    return self.am_wdIdentifier;
+  } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, identifier)]
+             || [wdAttributeName isEqualToString:AM_IDENTIFIER_ATTRIBUTE_NAME]) {
+    return self.am_identifier;
+  } else if ([wdAttributeName isEqualToString:AM_RECT_ATTRIBUTE_NAME]) {
+    return self.am_rect;
+  } else if ([wdAttributeName isEqualToString:AM_TEXT_ATTRIBUTE_NAME]) {
+    return self.am_text;
+  } else if ([wdAttributeName isEqualToString:AM_TYPE_ATTRIBUTE_NAME]) {
+    return self.am_type;
+  } else if ([wdAttributeName isEqualToString:AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME]) {
+    return FBBoolToStr(self.am_hasKeyboardInputFocus);
   }
   // This should not happen
   NSString *description = [NSString stringWithFormat:@"The attribute '%@' is unknown", wdAttributeName];
@@ -60,32 +75,64 @@
                                userInfo:@{}];
 }
 
-- (NSString *)am_wdIdentifier
++ (NSArray<NSString *> *)am_predicateAttributeNames
 {
-  NSString *identifier = self.identifier;
-  // Snapshotting is not free, so only pay for it when the fallback can apply.
-  if (identifier.length > 0 || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
-    return identifier;
+  return @[
+    AM_IDENTIFIER_ATTRIBUTE_NAME,
+    AM_RECT_ATTRIBUTE_NAME,
+    AM_TEXT_ATTRIBUTE_NAME,
+    AM_TYPE_ATTRIBUTE_NAME,
+    AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME,
+  ];
+}
+
++ (nullable id)am_valueForPredicateAttributeName:(NSString *)name target:(id)target
+{
+  if ([name isEqualToString:AM_IDENTIFIER_ATTRIBUTE_NAME]) {
+    NSString *identifier = [target valueForKey:@"identifier"];
+    // Snapshotting is not free, so only pay for it when the fallback can apply.
+    if (identifier.length > 0 || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
+      return identifier;
+    }
+    return [AMSnapshotUtils domIdentifierWithSnapshot:target] ?: identifier;
   }
-  return [AMSnapshotUtils wdIdentifierWithSnapshot:[self snapshotWithError:nil]] ?: identifier;
+  if ([name isEqualToString:AM_RECT_ATTRIBUTE_NAME]) {
+    return AMCGRectToDict([[target valueForKey:@"frame"] rectValue]);
+  }
+  if ([name isEqualToString:AM_TEXT_ATTRIBUTE_NAME]) {
+    return [self am_textWithSource:target];
+  }
+  if ([name isEqualToString:AM_TYPE_ATTRIBUTE_NAME]) {
+    return [FBElementTypeTransformer stringWithElementType:[[target valueForKey:@"elementType"] unsignedLongLongValue]];
+  }
+  if ([name isEqualToString:AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME]) {
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"hasKeyboardFocus == YES"];
+    return @([predicate evaluateWithObject:target]);
+  }
+  return nil;
+}
+
+- (NSString *)am_identifier
+{
+  return [self.class am_valueForPredicateAttributeName:AM_IDENTIFIER_ATTRIBUTE_NAME target:self];
 }
 
 - (NSDictionary<NSString *, NSNumber *> *)am_rect
 {
-  return AMCGRectToDict(self.frame);
+  return [self.class am_valueForPredicateAttributeName:AM_RECT_ATTRIBUTE_NAME target:self];
 }
 
 - (NSString *)am_text
 {
   if (!FBConfiguration.sharedConfiguration.fetchFullText) {
-    return [self am_textWithSource:self];
+    return [self.class am_valueForPredicateAttributeName:AM_TEXT_ATTRIBUTE_NAME target:self];
   }
 
   NSError *error;
   XCUIElementQuery *query = [self valueForKey:@"query"];
   id<XCUIElementAttributes> snapshot = [query am_uniqueSnapshotWithError:&error];
   if (nil != snapshot) {
-    return [self am_textWithSource:snapshot];
+    return [self.class am_valueForPredicateAttributeName:AM_TEXT_ATTRIBUTE_NAME target:snapshot];
   }
 
   NSString *reason = [NSString stringWithFormat:@"Cannot extract the full text of '%@' element. Original error: %@",
@@ -95,16 +142,15 @@
 
 - (NSString *)am_type
 {
-  return [FBElementTypeTransformer stringWithElementType:self.elementType];
+  return [self.class am_valueForPredicateAttributeName:AM_TYPE_ATTRIBUTE_NAME target:self];
 }
 
 - (BOOL)am_hasKeyboardInputFocus
 {
-  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"hasKeyboardFocus == YES"];
-  return [predicate evaluateWithObject:self];
+  return [[self.class am_valueForPredicateAttributeName:AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME target:self] boolValue];
 }
 
-- (NSString *)am_textWithSource:(id<XCUIElementAttributes>)source
++ (NSString *)am_textWithSource:(id<XCUIElementAttributes>)source
 {
   NSArray<NSString *> *candidates = @[
     [FBElementUtils stringValueWithValue:source.value],

--- a/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Categories/XCUIElement+AMAttributes.m
@@ -94,7 +94,12 @@ NSString *const AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME = @"amHasKeyboardInpu
     if (identifier.length > 0 || !FBConfiguration.sharedConfiguration.useDomIdAsAccessibilityId) {
       return identifier;
     }
-    return [AMSnapshotUtils domIdentifierWithSnapshot:target] ?: identifier;
+    // domIdentifierWithSnapshot: relies on snapshot-only key paths (_accessibilityElement._token),
+    // which a live XCUIElement does not have, so it must be snapshotted first.
+    id snapshotTarget = [target isKindOfClass:XCUIElement.class]
+      ? [(XCUIElement *)target snapshotWithError:nil]
+      : target;
+    return [AMSnapshotUtils domIdentifierWithSnapshot:snapshotTarget] ?: identifier;
   }
   if ([name isEqualToString:AM_RECT_ATTRIBUTE_NAME]) {
     return AMCGRectToDict([[target valueForKey:@"frame"] rectValue]);

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.h
@@ -44,6 +44,17 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString *)wdIdentifierWithSnapshot:(nullable id<XCUIElementSnapshot>)snapshot;
 
 /**
+ Whether this process is trusted for the Accessibility API. WebKit DOM identifier
+ resolution silently yields no results without this, since AXDOMIdentifier reads
+ fail with kAXErrorAPIDisabled - useful for tests and diagnostics to tell "no DOM id
+ fallback happened because the setting is off" apart from "no DOM id fallback
+ happened because this process lacks Accessibility permission".
+
+ @return YES if AXDOMIdentifier reads are expected to work, NO otherwise
+ */
++ (BOOL)isAccessibilityTrusted;
+
+/**
  Resolves snapshot hashes back to live elements below the given root element.
 
  @param hashes snapshot hashes to resolve, as returned by hashWithSnapshot:
@@ -56,6 +67,17 @@ NS_ASSUME_NONNULL_BEGIN
                                    rootElement:(XCUIElement *)rootElement
                                   rootSnapshot:(id<XCUIElementSnapshot>)rootSnapshot
                          includeOnlyFirstMatch:(BOOL)firstMatch;
+
+/**
+ Reads the non-standard AXDOMIdentifier attribute, where WebKit publishes a web
+ node's HTML `id`. Returns nil for native elements, which report
+ kAXErrorAttributeUnsupported for it, or when this process lacks Accessibility
+ permission.
+
+ @param snapshot snapshot instance to read the DOM identifier from
+ @return The DOM identifier or nil
+ */
++ (nullable NSString *)domIdentifierWithSnapshot:(nullable id)snapshot;
 
 @end
 

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/AMSnapshotUtils.m
@@ -65,17 +65,6 @@ static BOOL AMIsAccessibilityTrusted(void)
   return isTrusted;
 }
 
-@interface AMSnapshotUtils ()
-
-/**
- Reads the non-standard AXDOMIdentifier attribute, where WebKit publishes a web
- node's HTML `id`. Returns nil for native elements, which report
- kAXErrorAttributeUnsupported for it.
- */
-+ (nullable NSString *)domIdentifierWithSnapshot:(nullable id)snapshot;
-
-@end
-
 @implementation AMSnapshotUtils
 
 + (NSString *)hashWithSnapshot:(id)snapshot
@@ -92,6 +81,11 @@ static BOOL AMIsAccessibilityTrusted(void)
     return identifier;
   }
   return [self domIdentifierWithSnapshot:snapshot] ?: identifier;
+}
+
++ (BOOL)isAccessibilityTrusted
+{
+  return AMIsAccessibilityTrusted();
 }
 
 + (NSArray<XCUIElement *> *)elementsWithHashes:(NSSet<NSString *> *)hashes

--- a/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBElementUtils.m
+++ b/WebDriverAgentMac/WebDriverAgentLib/Utilities/FBElementUtils.m
@@ -11,6 +11,7 @@
 
 #import "FBExceptions.h"
 #import "FBMacros.h"
+#import "XCUIElement+AMAttributes.h"
 
 @implementation FBElementUtils
 
@@ -43,7 +44,12 @@
       FBStringify(XCUIElement, title),
       FBStringify(XCUIElement, value),
       FBStringify(XCUIElement, frame),
-      FBStringify(XCUIElement, identifier)
+      FBStringify(XCUIElement, identifier),
+      AM_IDENTIFIER_ATTRIBUTE_NAME,
+      AM_RECT_ATTRIBUTE_NAME,
+      AM_TEXT_ATTRIBUTE_NAME,
+      AM_TYPE_ATTRIBUTE_NAME,
+      AM_HAS_KEYBOARD_INPUT_FOCUS_ATTRIBUTE_NAME
     ];
   });
   return attributeNames;

--- a/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/project.pbxproj
+++ b/WebDriverAgentMac/WebDriverAgentMac.xcodeproj/project.pbxproj
@@ -65,8 +65,6 @@
 		7109C0402565B5C4006BFD13 /* NSPredicate+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 710527E82565731200130763 /* NSPredicate+FBFormat.m */; };
 		7109C0422565B5C7006BFD13 /* XCUIApplication+AMHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 710527FD2565802200130763 /* XCUIApplication+AMHelpers.h */; };
 		7109C0452565B5CB006BFD13 /* XCUIApplication+AMHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 710527FE2565802200130763 /* XCUIApplication+AMHelpers.m */; };
-		715AAB102F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.h in Headers */ = {isa = PBXBuildFile; fileRef = 715AAB122F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.h */; };
-		715AAB112F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.m in Sources */ = {isa = PBXBuildFile; fileRef = 715AAB132F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.m */; };
 		7109C0472565B5DB006BFD13 /* DDNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = 7151AD1E2564EFAC008B8B2A /* DDNumber.h */; };
 		7109C0492565B5DD006BFD13 /* DDNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 7151AD1D2564EFAC008B8B2A /* DDNumber.m */; };
 		7109C04B2565B5E0006BFD13 /* DDRange.h in Headers */ = {isa = PBXBuildFile; fileRef = 7151AD1F2564EFAC008B8B2A /* DDRange.h */; };
@@ -145,6 +143,8 @@
 		715117522E8C452E00C90122 /* AMPasteboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 715117512E8C452E00C90122 /* AMPasteboard.m */; };
 		715117532E8C452E00C90122 /* AMPasteboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 715117502E8C452E00C90122 /* AMPasteboard.h */; };
 		715117552E8C4C3300C90122 /* AMPasteboardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 715117542E8C4C3300C90122 /* AMPasteboardTests.m */; };
+		715AAB102F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.h in Headers */ = {isa = PBXBuildFile; fileRef = 715AAB122F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.h */; };
+		715AAB112F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.m in Sources */ = {isa = PBXBuildFile; fileRef = 715AAB132F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.m */; };
 		71688A98256461ED0007F55B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 71688A97256461ED0007F55B /* AppDelegate.m */; };
 		71688A9B256461ED0007F55B /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71688A9A256461ED0007F55B /* ViewController.m */; };
 		71688A9D256461F00007F55B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 71688A9C256461F00007F55B /* Assets.xcassets */; };
@@ -202,6 +202,8 @@
 		71A5C67A29A4FAF900421C37 /* FBFailureProofTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A5C67829A4FAF900421C37 /* FBFailureProofTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71AA30BF25EFF81900151CED /* AMKeyboardUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 71AA30BD25EFF81900151CED /* AMKeyboardUtils.h */; };
 		71AA30C025EFF81900151CED /* AMKeyboardUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71AA30BE25EFF81900151CED /* AMKeyboardUtils.m */; };
+		71AB00012BD1345000997FF4 /* WebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71AB00002BD1345000997FF4 /* WebViewController.m */; };
+		71AB00042BD1345000997FF4 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71AB00032BD1345000997FF4 /* WebKit.framework */; };
 		71B00E8E2566D4BA0010DA73 /* AMIntegrationTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B00E8D2566D4BA0010DA73 /* AMIntegrationTestCase.m */; };
 		71B00E9B2566D7B00010DA73 /* WebDriverAgentLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7199B3AB2565B122000B5C51 /* WebDriverAgentLib.framework */; };
 		71B00EA02566D9570010DA73 /* AMFindElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B00E9F2566D9570010DA73 /* AMFindElementTests.m */; };
@@ -264,8 +266,6 @@
 		710527F22565744400130763 /* FBSession-Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSession-Private.h"; sourceTree = "<group>"; };
 		710527FD2565802200130763 /* XCUIApplication+AMHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+AMHelpers.h"; sourceTree = "<group>"; };
 		710527FE2565802200130763 /* XCUIApplication+AMHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+AMHelpers.m"; sourceTree = "<group>"; };
-		715AAB122F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+AMAccessibilityAudit.h"; sourceTree = "<group>"; };
-		715AAB132F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+AMAccessibilityAudit.m"; sourceTree = "<group>"; };
 		710528162565A09100130763 /* FBScreenshotCommands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBScreenshotCommands.m; sourceTree = "<group>"; };
 		710528172565A09100130763 /* FBScreenshotCommands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBScreenshotCommands.h; sourceTree = "<group>"; };
 		7105281C2565A33300130763 /* FBSessionCommands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSessionCommands.m; sourceTree = "<group>"; };
@@ -395,6 +395,8 @@
 		7151AE302564FA37008B8B2A /* FBRuntimeUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBRuntimeUtils.h; sourceTree = "<group>"; };
 		7151AE352564FAAC008B8B2A /* FBUnknownCommands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBUnknownCommands.m; sourceTree = "<group>"; };
 		7151AE362564FAAC008B8B2A /* FBUnknownCommands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBUnknownCommands.h; sourceTree = "<group>"; };
+		715AAB122F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+AMAccessibilityAudit.h"; sourceTree = "<group>"; };
+		715AAB132F9C450000C90123 /* XCUIApplication+AMAccessibilityAudit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+AMAccessibilityAudit.m"; sourceTree = "<group>"; };
 		715C123827EB587100D6F63B /* XCTIssue+AMPatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTIssue+AMPatcher.h"; sourceTree = "<group>"; };
 		715C123927EB587100D6F63B /* XCTIssue+AMPatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCTIssue+AMPatcher.m"; sourceTree = "<group>"; };
 		71688A93256461ED0007F55B /* WebDriverAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WebDriverAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -460,6 +462,9 @@
 		71A5C67829A4FAF900421C37 /* FBFailureProofTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFailureProofTestCase.h; sourceTree = "<group>"; };
 		71AA30BD25EFF81900151CED /* AMKeyboardUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMKeyboardUtils.h; sourceTree = "<group>"; };
 		71AA30BE25EFF81900151CED /* AMKeyboardUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMKeyboardUtils.m; sourceTree = "<group>"; };
+		71AB00002BD1345000997FF4 /* WebViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WebViewController.m; sourceTree = "<group>"; };
+		71AB00022BD1345000997FF4 /* WebViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebViewController.h; sourceTree = "<group>"; };
+		71AB00032BD1345000997FF4 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		71B00E8B2566D4B90010DA73 /* IntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		71B00E8D2566D4BA0010DA73 /* AMIntegrationTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMIntegrationTestCase.m; sourceTree = "<group>"; };
 		71B00E8F2566D4BA0010DA73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -482,6 +487,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71AB00042BD1345000997FF4 /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -611,6 +617,8 @@
 				71688A97256461ED0007F55B /* AppDelegate.m */,
 				71688A99256461ED0007F55B /* ViewController.h */,
 				71688A9A256461ED0007F55B /* ViewController.m */,
+				71AB00022BD1345000997FF4 /* WebViewController.h */,
+				71AB00002BD1345000997FF4 /* WebViewController.m */,
 				71688A9C256461F00007F55B /* Assets.xcassets */,
 				71688A9E256461F00007F55B /* Main.storyboard */,
 				71688AA1256461F00007F55B /* Info.plist */,
@@ -626,6 +634,7 @@
 				714CA732256668F600353B27 /* XCTAutomationSupport.framework */,
 				714CA709256648A100353B27 /* libxml2.tbd */,
 				71688AE2256466070007F55B /* XCTest.framework */,
+				71AB00032BD1345000997FF4 /* WebKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1159,6 +1168,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				71688A9B256461ED0007F55B /* ViewController.m in Sources */,
+				71AB00012BD1345000997FF4 /* WebViewController.m in Sources */,
 				71688AA3256461F00007F55B /* main.m in Sources */,
 				71688A98256461ED0007F55B /* AppDelegate.m in Sources */,
 			);

--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -37,40 +37,44 @@ e.g. `amIdentifier == 'my-dom-id'`.
 
 > Example: `{"x": 0,"y": 0,"width": 100,"height": 100}`
 
-Non-standard, Mac2-driver-specific alias for [`frame`](#frame), with the exact same value. Unlike
-`frame`, it can also be used in [predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
-reliably match against `WKWebView` web elements.
+Non-standard, Mac2-driver-specific alias for [`frame`](#frame), with the exact same value. `frame`
+is a structured rectangle value that predicate/class chain expressions cannot compare against the
+driver's `{x, y, width, height}` dictionary shape shown above. `amRect` resolves to that same
+dictionary shape, so it can be used in
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators instead.
 
 ## amText
 
 > Example: `my text`
 
-Non-standard, Mac2-driver-specific attribute. The element's text: the first non-empty value out
-of its `value`, `label`, `placeholderValue` and `title`, in that order, or an empty string if all
-of them are empty. Unlike those individual attributes, it can be used in
+Non-standard, Mac2-driver-specific attribute with no native XCTest equivalent: the first non-empty
+value out of the element's `value`, `label`, `placeholderValue` and `title`, in that order, or an
+empty string if all of them are empty. Because there is no such attribute on the XCTest side, it
+can only be read through this alias, including from
 [predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
-reliably match against `WKWebView` web elements.
+[class chain](./locator-strategies.md#class-chain) locators.
 
 ## amType
 
 > Example: `XCUIElementTypeButton`
 
 Non-standard, Mac2-driver-specific alias for [`elementType`](#elementtype), except as its string
-name (e.g. `XCUIElementTypeButton`) instead of the integer code. Unlike `elementType`, it can also
-be used in [predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
-reliably match against `WKWebView` web elements.
+name (e.g. `XCUIElementTypeButton`) instead of the integer code. Unlike `elementType`, it can be
+compared against type name strings directly in
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators.
 
 ## amHasKeyboardInputFocus
 
 > Example: `true`
 
 Non-standard, Mac2-driver-specific alias for [`focused`](#focused), with the exact same value.
-Unlike `focused`, it can also be used in [predicate string](./locator-strategies.md#predicate-string)
-and [class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain)
-to reliably match against `WKWebView` web elements.
+XCTest does not expose any focus-related property through its public element attributes protocol
+on macOS, so `focused` cannot be referenced directly from predicate/class chain expressions at
+all. `amHasKeyboardInputFocus` makes that value available to
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators.
 
 ## label
 

--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -21,6 +21,57 @@ integer-encoded value.
 Corresponds to the element's XCTest [`identifier`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/identifier)
 value. Can be `null`.
 
+## amIdentifier
+
+> Example: `identifier`
+
+Non-standard, Mac2-driver-specific alias for [`identifier`](#identifier), with the exact same
+value and the exact same [`useDomIdAsAccessibilityId`](./settings.md#usedomidasaccessibilityid)-gated
+DOM id fallback behavior. Its only difference from `identifier` is that, unlike `identifier`,
+it can also be used in [predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
+reliably match against, including web elements by their DOM id when the setting above is enabled,
+e.g. `amIdentifier == 'my-dom-id'`.
+
+## amRect
+
+> Example: `{"x": 0,"y": 0,"width": 100,"height": 100}`
+
+Non-standard, Mac2-driver-specific alias for [`frame`](#frame), with the exact same value. Unlike
+`frame`, it can also be used in [predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
+reliably match against `WKWebView` web elements.
+
+## amText
+
+> Example: `my text`
+
+Non-standard, Mac2-driver-specific attribute. The element's text: the first non-empty value out
+of its `value`, `label`, `placeholderValue` and `title`, in that order, or an empty string if all
+of them are empty. Unlike those individual attributes, it can be used in
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
+reliably match against `WKWebView` web elements.
+
+## amType
+
+> Example: `XCUIElementTypeButton`
+
+Non-standard, Mac2-driver-specific alias for [`elementType`](#elementtype), except as its string
+name (e.g. `XCUIElementTypeButton`) instead of the integer code. Unlike `elementType`, it can also
+be used in [predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
+reliably match against `WKWebView` web elements.
+
+## amHasKeyboardInputFocus
+
+> Example: `true`
+
+Non-standard, Mac2-driver-specific alias for [`focused`](#focused), with the exact same value.
+Unlike `focused`, it can also be used in [predicate string](./locator-strategies.md#predicate-string)
+and [class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain)
+to reliably match against `WKWebView` web elements.
+
 ## label
 
 > Examples: `my label`

--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -21,62 +21,7 @@ integer-encoded value.
 Corresponds to the element's XCTest [`identifier`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/identifier)
 value. Can be `null`.
 
-## amIdentifier
-
-> Example: `identifier`
-
-Non-standard, Mac2-driver-specific alias for [`identifier`](#identifier), with the exact same
-value and the exact same [`useDomIdAsAccessibilityId`](./settings.md#usedomidasaccessibilityid)-gated
-DOM id fallback behavior. Its only difference from `identifier` is that, unlike `identifier`,
-it can also be used in [predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
-reliably match against, including web elements by their DOM id when the setting above is enabled,
-e.g. `amIdentifier == 'my-dom-id'`.
-
-## amRect
-
-> Example: `{"x": 0,"y": 0,"width": 100,"height": 100}`
-
-Non-standard, Mac2-driver-specific alias for [`frame`](#frame), with the exact same value. `frame`
-is a structured rectangle value that predicate/class chain expressions cannot compare against the
-driver's `{x, y, width, height}` dictionary shape shown above. `amRect` resolves to that same
-dictionary shape, so it can be used in
-[predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators instead.
-
-## amText
-
-> Example: `my text`
-
-Non-standard, Mac2-driver-specific attribute with no native XCTest equivalent: the first non-empty
-value out of the element's `value`, `label`, `placeholderValue` and `title`, in that order, or an
-empty string if all of them are empty. Because there is no such attribute on the XCTest side, it
-can only be read through this alias, including from
-[predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators.
-
-## amType
-
-> Example: `XCUIElementTypeButton`
-
-Non-standard, Mac2-driver-specific alias for [`elementType`](#elementtype), except as its string
-name (e.g. `XCUIElementTypeButton`) instead of the integer code. Unlike `elementType`, it can be
-compared against type name strings directly in
-[predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators.
-
-## amHasKeyboardInputFocus
-
-> Example: `true`
-
-Non-standard, Mac2-driver-specific alias for [`focused`](#focused), with the exact same value.
-XCTest does not expose any focus-related property through its public element attributes protocol
-on macOS, so `focused` cannot be referenced directly from predicate/class chain expressions at
-all. `amHasKeyboardInputFocus` makes that value available to
-[predicate string](./locator-strategies.md#predicate-string) and
-[class chain](./locator-strategies.md#class-chain) locators.
-
-## label
+## label
 
 > Examples: `my label`
 
@@ -142,3 +87,58 @@ value.
 
 Corresponds to the element's XCTest [`frame`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/frame)
 value.
+
+## amIdentifier
+
+> Example: `my-dom-id`
+
+Non-standard, Mac2-driver-specific alias for [`identifier`](#identifier), with the exact same
+value and the exact same [`useDomIdAsAccessibilityId`](./settings.md#usedomidasaccessibilityid)-gated
+DOM id fallback behavior. Its only difference from `identifier` is that, unlike `identifier`,
+it can also be used in [predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators (at any position in a class chain) to
+reliably match against, including web elements by their DOM id when the setting above is enabled,
+e.g. `amIdentifier == 'my-dom-id'`.
+
+## amRect
+
+> Example: `{"x": 0,"y": 0,"width": 100,"height": 100}`
+
+Non-standard, Mac2-driver-specific alias for [`frame`](#frame), with the exact same value. `frame`
+is a structured rectangle value that predicate/class chain expressions cannot compare against the
+driver's `{x, y, width, height}` dictionary shape shown above. `amRect` resolves to that same
+dictionary shape, so it can be used in
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators instead.
+
+## amText
+
+> Example: `my text`
+
+Non-standard, Mac2-driver-specific attribute with no native XCTest equivalent: the first non-empty
+value out of the element's `value`, `label`, `placeholderValue` and `title`, in that order, or an
+empty string if all of them are empty. Because there is no such attribute on the XCTest side, it
+can only be read through this alias, including from
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators.
+
+## amType
+
+> Example: `XCUIElementTypeButton`
+
+Non-standard, Mac2-driver-specific alias for [`elementType`](#elementtype), except as its string
+name (e.g. `XCUIElementTypeButton`) instead of the integer code. Unlike `elementType`, it can be
+compared against type name strings directly in
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators.
+
+## amHasKeyboardInputFocus
+
+> Example: `true`
+
+Non-standard, Mac2-driver-specific alias for [`focused`](#focused), with the exact same value.
+XCTest does not expose any focus-related property through its public element attributes protocol
+on macOS, so `focused` cannot be referenced directly from predicate/class chain expressions at
+all. `amHasKeyboardInputFocus` makes that value available to
+[predicate string](./locator-strategies.md#predicate-string) and
+[class chain](./locator-strategies.md#class-chain) locators.

--- a/docs/reference/locator-strategies.md
+++ b/docs/reference/locator-strategies.md
@@ -61,12 +61,14 @@ This strategy is an alias for the [`name` strategy](#name).
 This strategy is mapped to the native XCTest predicate locator. Refer to the XCUITest driver's
 [Predicate Locator Strategy guide](https://appium.github.io/appium-xcuitest-driver/latest/reference/ios-predicate/)
 for more details on how to build effective predicate expressions. All supported element [attributes](./element-attributes.md)
-can be used in these expressions, except that most `WKWebView` web element attributes cannot be
-reliably matched directly - use the `am`-prefixed aliases instead:
-[`amIdentifier`](./element-attributes.md#amidentifier), [`amRect`](./element-attributes.md#amrect),
-[`amText`](./element-attributes.md#amtext), [`amType`](./element-attributes.md#amtype) and
-[`amHasKeyboardInputFocus`](./element-attributes.md#amhaskeyboardinputfocus), e.g.
-`amIdentifier == 'done'`.
+can be used in these expressions. A few of them have no native XCTest equivalent that predicate
+expressions can reference directly, so they are only usable through their `am`-prefixed alias:
+[`amRect`](./element-attributes.md#amrect), [`amText`](./element-attributes.md#amtext),
+[`amType`](./element-attributes.md#amtype) and
+[`amHasKeyboardInputFocus`](./element-attributes.md#amhaskeyboardinputfocus). Separately,
+[`amIdentifier`](./element-attributes.md#amidentifier) is the only reliable way to match
+`WKWebView` web elements by their DOM id from this strategy - see
+[`useDomIdAsAccessibilityId`](./settings.md#usedomidasaccessibilityid) - e.g. `amIdentifier == 'done'`.
 
 !!! info "When to Use"
 
@@ -83,8 +85,8 @@ This strategy is mapped to the native XCTest predicate locator, but with respect
 element tree hierarchy. Such locators are basically a supertype of [predicate string](#predicate-string).
 Read [Class Chain Queries Construction Rules](https://github.com/facebookarchive/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules)
 for more details on how to build such locators. As with predicate string, the `am`-prefixed
-attribute aliases can be used to reliably match `WKWebView` web elements, at any position in the
-chain.
+attribute aliases can be used at any position in the chain, including `amIdentifier` to reliably
+match `WKWebView` web elements by their DOM id.
 
 !!! info "When to Use"
 

--- a/docs/reference/locator-strategies.md
+++ b/docs/reference/locator-strategies.md
@@ -61,7 +61,12 @@ This strategy is an alias for the [`name` strategy](#name).
 This strategy is mapped to the native XCTest predicate locator. Refer to the XCUITest driver's
 [Predicate Locator Strategy guide](https://appium.github.io/appium-xcuitest-driver/latest/reference/ios-predicate/)
 for more details on how to build effective predicate expressions. All supported element [attributes](./element-attributes.md)
-can be used in these expressions.
+can be used in these expressions, except that most `WKWebView` web element attributes cannot be
+reliably matched directly - use the `am`-prefixed aliases instead:
+[`amIdentifier`](./element-attributes.md#amidentifier), [`amRect`](./element-attributes.md#amrect),
+[`amText`](./element-attributes.md#amtext), [`amType`](./element-attributes.md#amtype) and
+[`amHasKeyboardInputFocus`](./element-attributes.md#amhaskeyboardinputfocus), e.g.
+`amIdentifier == 'done'`.
 
 !!! info "When to Use"
 
@@ -77,7 +82,9 @@ can be used in these expressions.
 This strategy is mapped to the native XCTest predicate locator, but with respect to the actual
 element tree hierarchy. Such locators are basically a supertype of [predicate string](#predicate-string).
 Read [Class Chain Queries Construction Rules](https://github.com/facebookarchive/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules)
-for more details on how to build such locators.
+for more details on how to build such locators. As with predicate string, the `am`-prefixed
+attribute aliases can be used to reliably match `WKWebView` web elements, at any position in the
+chain.
 
 !!! info "When to Use"
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -64,6 +64,13 @@ driver reads `AXDOMIdentifier` and uses it as a fallback for `accessibility id` 
 `identifier` attribute and for the page source. The fallback only applies to elements whose native
 identifier is empty, so locating native elements is never affected.
 
+Native XCTest predicate/class chain matching cannot reliably observe this fallback for the
+standard `identifier` attribute. To locate web elements by DOM id from `predicate string` or
+`class chain` locators, use the [`amIdentifier`](./element-attributes.md#amidentifier) attribute
+instead - it has the exact same value and the exact same setting-gated fallback behavior as
+`identifier`, but can be reliably matched from these locators too, at any position in a class
+chain.
+
 Notes:
 
 - Enabling this makes `accessibility id` lookups that find no native match inspect the


### PR DESCRIPTION
XCTest's native predicate/class chain matching cannot reliably observe web elements' attributes, so predicates like `identifier == 'x'` never match WKWebView content even when it's otherwise reachable. Add am_-prefixed attribute aliases (amIdentifier, amRect, amText, amType, amHasKeyboardInputFocus) that predicate string and class chain locators can match against reliably instead, at any position in a class chain, by rewriting comparisons against them into block predicates resolved directly off the snapshot node being matched.

Also add a real WKWebView to the WebDriverAgentMac integration app so this, and the existing accessibility id DOM-id fallback from #405, can be exercised against real web content instead of just asserting "finds nothing extra".